### PR TITLE
fix apt install prometheus failed for apt cache not update

### DIFF
--- a/deploy/roles/monitor/tasks/main.yml
+++ b/deploy/roles/monitor/tasks/main.yml
@@ -28,6 +28,13 @@
           - targets: ['{{ ip }}:9177']
           {% endfor %}
 
+- name: Update apt cache
+  delegate_to: "{{ prometheus_server_ip }}"
+  become: true
+  apt:
+    update_cache: yes
+  tags: [monitor]
+
 - name: Install packages for monitor server
   delegate_to: "{{ prometheus_server_ip }}"
   become: true


### PR DESCRIPTION
fix apt install failed for apt cache not update