### PR TITLE
PET-1140-fix-slack-notify-empty-key-and-ip-support-dup-control

### DIFF
--- a/deploy/roles/monitor/tasks/main.yml
+++ b/deploy/roles/monitor/tasks/main.yml
@@ -442,7 +442,7 @@
               # Node vCPU alerts → slack-resource-alerts
               - match:
                   alert_type: node-vcpu
-                group_by: ['alertname', 'instance', 'hostname', 'alert_type', 'severity', 'node_type']
+                group_by: ['alertname', 'zone', 'region', 'alert_type', 'severity', 'node_type']
                 receiver: 'slack-resource-alerts'
                 continue: true
 

--- a/deploy/roles/monitor/templates/ipgroup-available-ip-monitor.yml.j2
+++ b/deploy/roles/monitor/templates/ipgroup-available-ip-monitor.yml.j2
@@ -3,13 +3,14 @@ groups:
   rules:
     - alert: IPGroupLowAvailableIPs
       # Monitor available IP count in subnets
+      # Fix many-to-many matching by deduplicating both sides (HA deployment has 2 exporters)
       expr: |
-        (
+        max by (ipgroup_id, subnet_id, region) (
           cloudland_subnet_ip_available < {{ threshold | default(100) }}
         )
         * on (ipgroup_id, subnet_id, region)
-          group_left(ipgroup_name)
-          cloudland_subnet_info
+          group_left(ipgroup_name, subnet_name)
+          max by (ipgroup_id, subnet_id, region, ipgroup_name, subnet_name) (cloudland_subnet_info)
       for: {{ for_duration | default("5m") }}
       labels:
         severity: {{ severity | default("warning") }}


### PR DESCRIPTION
PET-1140-fix-slack-notify-empty-key-and-ip-support-dup-control