### PR TITLE
fix: memory leaks, null ptr dereference, GORM tag syntax, and code style

### DIFF
--- a/sci/common/socket.cpp
+++ b/sci/common/socket.cpp
@@ -13,7 +13,7 @@
  Classes: Socket, SocketException
 
  Description: Socket manipulation.
-   
+
  Author: Tu HongJ, Liu Wei
 
  History:
@@ -25,489 +25,451 @@
 
 #include <assert.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <netinet/tcp.h>
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
-#include <netinet/tcp.h>
 #include <unistd.h>
-#include <fcntl.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <poll.h>
 
+#include "ipconverter.hpp"
 #include "socket.hpp"
 #include "tools.hpp"
-#include "ipconverter.hpp"
-
 
 #define CONNECTING_TIMES 30
 
 int Socket::disableIpv6 = 0;
 int Socket::connTimes = CONNECTING_TIMES;
 
-Socket::Socket(int sockfd)
-    : socket(sockfd)
-{
-	int i = 0;
+Socket::Socket(int sockfd) : socket(sockfd) {
+  int i = 0;
 
-    numListenfds = 0;
-	for (i = 0; i < NELEMS(accSockets); i++) {
-        accSockets[i] = -1;
-    }
+  numListenfds = 0;
+  for (i = 0; i < NELEMS(accSockets); i++) {
+    accSockets[i] = -1;
+  }
 }
 
-Socket::~Socket()
-{
-	int i = 0;
+Socket::~Socket() {
+  int i = 0;
 
-	for (i = 0; i < NELEMS(accSockets); i++) {
-        ::close(accSockets[i]);
-    }
-    ::close(socket);
+  for (i = 0; i < NELEMS(accSockets); i++) {
+    ::close(accSockets[i]);
+  }
+  ::close(socket);
 }
 
-int Socket::setMode(int sockfd, bool mode)
-{
-    int flags, newflags;
+int Socket::setMode(int sockfd, bool mode) {
+  int flags, newflags;
 
-    flags = ::fcntl(sockfd, F_GETFL);
-    if (flags < 0)
-        throw SocketException(SocketException::NET_ERR_FCNTL, errno);
+  flags = ::fcntl(sockfd, F_GETFL);
+  if (flags < 0)
+    throw SocketException(SocketException::NET_ERR_FCNTL, errno);
 
-    if (mode)
-        newflags = flags & ~O_NONBLOCK;
-    else
-        newflags = flags | O_NONBLOCK;
+  if (mode)
+    newflags = flags & ~O_NONBLOCK;
+  else
+    newflags = flags | O_NONBLOCK;
 
-    if (newflags != flags) {
-        if (::fcntl(sockfd, F_SETFL, newflags) < 0) {
-            throw SocketException(SocketException::NET_ERR_FCNTL, errno);
-        }
+  if (newflags != flags) {
+    if (::fcntl(sockfd, F_SETFL, newflags) < 0) {
+      throw SocketException(SocketException::NET_ERR_FCNTL, errno);
     }
-    
-    return 0;
+  }
+
+  return 0;
 }
 
-int Socket::setFd(int fd)
-{
-    if (fd < 0) {
-        throw SocketException(SocketException::NET_ERR_SOCKET, errno);
-    }
-    socket = fd;
-    setOpts(socket);
+int Socket::setFd(int fd) {
+  if (fd < 0) {
+    throw SocketException(SocketException::NET_ERR_SOCKET, errno);
+  }
+  socket = fd;
+  setOpts(socket);
 
-    return 0;
+  return 0;
 }
 
-int Socket::setOpts(int sockfd)
-{
-    int value = 1;
+int Socket::setOpts(int sockfd) {
+  int value = 1;
 
-    setsockopt(sockfd, SOL_SOCKET, SO_KEEPALIVE, (void *)&value, sizeof(value));
-    value = 60;
-    setsockopt(sockfd, SOL_TCP, TCP_KEEPIDLE, (void*)&value, sizeof(value));
-    value = 5;
-    setsockopt(sockfd, SOL_TCP, TCP_KEEPINTVL, (void *)&value, sizeof(value));
-    value = 3;
-    setsockopt(sockfd, SOL_TCP, TCP_KEEPCNT, (void *)&value, sizeof(value));
-    value = 1;
-    setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, (void *)&value, sizeof(value));
+  setsockopt(sockfd, SOL_SOCKET, SO_KEEPALIVE, (void *)&value, sizeof(value));
+  value = 60;
+  setsockopt(sockfd, SOL_TCP, TCP_KEEPIDLE, (void *)&value, sizeof(value));
+  value = 5;
+  setsockopt(sockfd, SOL_TCP, TCP_KEEPINTVL, (void *)&value, sizeof(value));
+  value = 3;
+  setsockopt(sockfd, SOL_TCP, TCP_KEEPCNT, (void *)&value, sizeof(value));
+  value = 1;
+  setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, (void *)&value, sizeof(value));
 
-    return 0;
+  return 0;
 }
 
-int Socket::listen(int &port, char *hname)
-{
-    int sockfd;
-    int yes, rc;
-	int accCount = 0;
-    struct addrinfo hints, *host, *ressave;
-    char service[NI_MAXSERV] = {0};
+int Socket::listen(int &port, char *hname) {
+  int sockfd;
+  int yes, rc;
+  int accCount = 0;
+  struct addrinfo hints, *host, *ressave;
+  char service[NI_MAXSERV] = {0};
 
-    ::memset(&hints, 0, sizeof(struct addrinfo));
-    hints.ai_flags = (hname == NULL) ? AI_PASSIVE : 0;
-    hints.ai_family = AF_UNSPEC;
-    hints.ai_socktype = SOCK_STREAM;
-    ::sprintf(service, "%d", port);
-    ::getaddrinfo(hname, service, &hints, &host);
-    ressave = host;
+  ::memset(&hints, 0, sizeof(struct addrinfo));
+  hints.ai_flags = (hname == NULL) ? AI_PASSIVE : 0;
+  hints.ai_family = AF_UNSPEC;
+  hints.ai_socktype = SOCK_STREAM;
+  ::sprintf(service, "%d", port);
+  ::getaddrinfo(hname, service, &hints, &host);
+  ressave = host;
 
-    while (host && (accCount < NELEMS(accSockets))) {
-		if ((host->ai_family != AF_INET) && (host->ai_family != AF_INET6)) {
-            host = host->ai_next;
-            continue;
-        }
-
-        if ((host->ai_family == AF_INET6) && (getDisableIPv6() == 1)) {
-            host = host->ai_next;
-            continue;
-        }
-
-        sockfd = ::socket(host->ai_family, host->ai_socktype, host->ai_protocol);
-        if (sockfd >= 0) {
-			yes = 1;
-			rc = ::setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
-			if (host->ai_family == AF_INET6) {
-				setsockopt(sockfd, IPPROTO_IPV6, IPV6_V6ONLY, &yes, sizeof(yes));
-				sockaddr_in6 *addr6 = (sockaddr_in6 *)host->ai_addr;
-				if (port != 0)
-					addr6->sin6_port = htons(port);
-			} else {
-				sockaddr_in *addr4 = (sockaddr_in *)host->ai_addr;
-				if (port != 0)
-					addr4->sin_port = htons(port);
-			}
-			setMode(sockfd, false);
-            rc = ::bind(sockfd, host->ai_addr, host->ai_addrlen);
-            if (rc == 0) {
-                struct sockaddr_storage sockaddr;
-                socklen_t len = sizeof(sockaddr);
-
-                ::getsockname(sockfd, (struct sockaddr *)&sockaddr, &len);
-                ::getnameinfo((struct sockaddr *)&sockaddr, len, NULL, 0,
-                        service, sizeof(service), NI_NUMERICSERV);
-                port = ::atoi(service);
-				rc = ::listen(sockfd, SOMAXCONN);
-                accSockets[accCount] = sockfd;
-				accCount++;
-            } else {
-				::close(sockfd);
-			}
-        }
-        host = host->ai_next;
+  while (host && (accCount < NELEMS(accSockets))) {
+    if ((host->ai_family != AF_INET) && (host->ai_family != AF_INET6)) {
+      host = host->ai_next;
+      continue;
     }
 
-    if (accCount <= 0) {
-        throw SocketException(SocketException::NET_ERR_BIND, errno);
-    }
-    ::freeaddrinfo(ressave);
-
-    numListenfds = accCount;
-    return accCount;
-}
-
-int Socket::iflisten(int & port, const string & ifname)
-{
-    int accCount = 0;
-    char service[NI_MAXSERV] = {0};
-    ::sprintf(service, "%d", port);
-    
-    int sockfd = ::socket(AF_INET, SOCK_STREAM, 0);
-    if (sockfd < 0) {
-        throw SocketException(SocketException::NET_ERR_SOCKET, errno);
+    if ((host->ai_family == AF_INET6) && (getDisableIPv6() == 1)) {
+      host = host->ai_next;
+      continue;
     }
 
-    int yes = 1;
-    ::setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
-
-    IPConverter converter;
-    struct sockaddr_in addr;
-    converter.getIP(ifname, true, &addr);
-
-    int rc = ::bind(sockfd, (struct sockaddr *)&addr, sizeof(addr));
-    if (rc == 0) {
+    sockfd = ::socket(host->ai_family, host->ai_socktype, host->ai_protocol);
+    if (sockfd >= 0) {
+      yes = 1;
+      rc = ::setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
+      if (host->ai_family == AF_INET6) {
+        setsockopt(sockfd, IPPROTO_IPV6, IPV6_V6ONLY, &yes, sizeof(yes));
+        sockaddr_in6 *addr6 = (sockaddr_in6 *)host->ai_addr;
+        if (port != 0)
+          addr6->sin6_port = htons(port);
+      } else {
+        sockaddr_in *addr4 = (sockaddr_in *)host->ai_addr;
+        if (port != 0)
+          addr4->sin_port = htons(port);
+      }
+      setMode(sockfd, false);
+      rc = ::bind(sockfd, host->ai_addr, host->ai_addrlen);
+      if (rc == 0) {
         struct sockaddr_storage sockaddr;
         socklen_t len = sizeof(sockaddr);
 
         ::getsockname(sockfd, (struct sockaddr *)&sockaddr, &len);
-        ::getnameinfo((struct sockaddr *)&sockaddr, len, NULL, 0,
-            service, sizeof(service), NI_NUMERICSERV);
+        ::getnameinfo((struct sockaddr *)&sockaddr, len, NULL, 0, service,
+                      sizeof(service), NI_NUMERICSERV);
         port = ::atoi(service);
-    } else {
-        throw SocketException(SocketException::NET_ERR_BIND, errno);
-    }
-
-    ::listen(sockfd, SOMAXCONN);
-    accSockets[accCount] = sockfd;
-    accCount++;
-    numListenfds = accCount;
-
-    return sockfd;
-}
-
-int Socket::connect(const char *hostName, in_port_t port)
-{
-    int rc = -1;
-    int sockfd;
-    char service[NI_MAXSERV] = {0};
-    struct addrinfo *host = NULL, *ressave;
-    int count = 0;
-	bool connected = false;
-    char *envp = NULL;
-
-    envp = getenv("SCI_RECONN_TIME");
-    if (envp != NULL) {
-        int tmp = atoi(envp);
-        if (tmp > 0) {
-            connTimes = tmp * 10;
-        }
-    }
-    while (count < connTimes) {
-        struct addrinfo hints = {0};
-        ::sprintf(service, "%d", port);
-        hints.ai_family = AF_UNSPEC;
-        hints.ai_socktype = SOCK_STREAM;
-        hints.ai_flags = AI_NUMERICHOST | AI_NUMERICSERV;
-
-        rc = ::getaddrinfo(hostName, service, &hints, &host);
-        if (rc == EAI_NONAME) {
-            hints.ai_flags = 0;
-            rc = ::getaddrinfo(hostName, service, &hints, &host);
-        }
-        if (!host) {
-            throw SocketException(SocketException::NET_ERR_GETADDRINFO, errno);
-        }
-
-		ressave = host;
-        while (host) {
-            if ((host->ai_family == AF_INET6) && (getDisableIPv6() == 1)) {
-                host = host->ai_next;
-                continue;
-            }
-
-			sockfd = ::socket(host->ai_family, host->ai_socktype, host->ai_protocol);
-			if (sockfd < 0) {
-				::freeaddrinfo(host);
-				throw SocketException(SocketException::NET_ERR_SOCKET, errno);
-			}
-
-			rc = ::connect(sockfd, host->ai_addr, host->ai_addrlen);
-			if (rc == 0) {
-                rc = setOpts(sockfd);
-				connected = true;
-				break;
-			}
-			host = host->ai_next;
-		}
-        count++;
-        ::freeaddrinfo(ressave);
-		if (connected)
-			break;
-
+        rc = ::listen(sockfd, SOMAXCONN);
+        accSockets[accCount] = sockfd;
+        accCount++;
+      } else {
         ::close(sockfd);
-        SysUtil::sleep(100000);
+      }
     }
-    if (rc < 0) {
-        throw SocketException(SocketException::NET_ERR_CONNECT, errno);
-    }
-    socket = sockfd;
+    host = host->ai_next;
+  }
 
-    return sockfd;
+  if (accCount <= 0) {
+    throw SocketException(SocketException::NET_ERR_BIND, errno);
+  }
+  ::freeaddrinfo(ressave);
+
+  numListenfds = accCount;
+  return accCount;
 }
 
-int Socket::stopAccept()
-{
-	int i = 0;
+int Socket::iflisten(int &port, const string &ifname) {
+  int accCount = 0;
+  char service[NI_MAXSERV] = {0};
+  ::sprintf(service, "%d", port);
 
-	for (i = 0; i < NELEMS(accSockets); i++) {
-        if (accSockets[i] != -1) {
-            ::shutdown(accSockets[i], SHUT_RDWR);
-            ::close(accSockets[i]);
-            accSockets[i] = -1;
-        }
-	}
+  int sockfd = ::socket(AF_INET, SOCK_STREAM, 0);
+  if (sockfd < 0) {
+    throw SocketException(SocketException::NET_ERR_SOCKET, errno);
+  }
 
-	return 0;
-}
+  int yes = 1;
+  ::setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
 
-int Socket::accept()
-{
-    int client = -1;
+  IPConverter converter;
+  struct sockaddr_in addr;
+  if (converter.getIP(ifname, true, &addr) != 0) {
+    throw SocketException(SocketException::NET_ERR_BIND, errno);
+  }
+  addr.sin_port = htons(port);
+
+  int rc = ::bind(sockfd, (struct sockaddr *)&addr, sizeof(addr));
+  if (rc == 0) {
     struct sockaddr_storage sockaddr;
     socklen_t len = sizeof(sockaddr);
-	int i = 0;
-	int n = 0;
-    struct pollfd fds[NELEMS(accSockets)] = {0};
-    int accCount = 0;
 
-    for (i = 0; i < NELEMS(accSockets); i++){
-        if (accSockets[i] == -1) {
-            break;
+    ::getsockname(sockfd, (struct sockaddr *)&sockaddr, &len);
+    ::getnameinfo((struct sockaddr *)&sockaddr, len, NULL, 0, service,
+                  sizeof(service), NI_NUMERICSERV);
+    port = ::atoi(service);
+  } else {
+    throw SocketException(SocketException::NET_ERR_BIND, errno);
+  }
+
+  ::listen(sockfd, SOMAXCONN);
+  accSockets[accCount] = sockfd;
+  accCount++;
+  numListenfds = accCount;
+
+  return sockfd;
+}
+
+int Socket::connect(const char *hostName, in_port_t port) {
+  int rc = -1;
+  int sockfd;
+  char service[NI_MAXSERV] = {0};
+  struct addrinfo *host = NULL, *ressave;
+  int count = 0;
+  bool connected = false;
+  char *envp = NULL;
+
+  envp = getenv("SCI_RECONN_TIME");
+  if (envp != NULL) {
+    int tmp = atoi(envp);
+    if (tmp > 0) {
+      connTimes = tmp * 10;
+    }
+  }
+  while (count < connTimes) {
+    struct addrinfo hints = {0};
+    ::sprintf(service, "%d", port);
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = AI_NUMERICHOST | AI_NUMERICSERV;
+
+    rc = ::getaddrinfo(hostName, service, &hints, &host);
+    if (rc == EAI_NONAME) {
+      hints.ai_flags = 0;
+      rc = ::getaddrinfo(hostName, service, &hints, &host);
+    }
+    if (!host) {
+      throw SocketException(SocketException::NET_ERR_GETADDRINFO, errno);
+    }
+
+    ressave = host;
+    while (host) {
+      if ((host->ai_family == AF_INET6) && (getDisableIPv6() == 1)) {
+        host = host->ai_next;
+        continue;
+      }
+
+      sockfd = ::socket(host->ai_family, host->ai_socktype, host->ai_protocol);
+      if (sockfd < 0) {
+        ::freeaddrinfo(host);
+        throw SocketException(SocketException::NET_ERR_SOCKET, errno);
+      }
+
+      rc = ::connect(sockfd, host->ai_addr, host->ai_addrlen);
+      if (rc == 0) {
+        rc = setOpts(sockfd);
+        connected = true;
+        break;
+      }
+      host = host->ai_next;
+    }
+    count++;
+    ::freeaddrinfo(ressave);
+    if (connected)
+      break;
+
+    ::close(sockfd);
+    SysUtil::sleep(100000);
+  }
+  if (rc < 0) {
+    throw SocketException(SocketException::NET_ERR_CONNECT, errno);
+  }
+  socket = sockfd;
+
+  return sockfd;
+}
+
+int Socket::stopAccept() {
+  int i = 0;
+
+  for (i = 0; i < NELEMS(accSockets); i++) {
+    if (accSockets[i] != -1) {
+      ::shutdown(accSockets[i], SHUT_RDWR);
+      ::close(accSockets[i]);
+      accSockets[i] = -1;
+    }
+  }
+
+  return 0;
+}
+
+int Socket::accept() {
+  int client = -1;
+  struct sockaddr_storage sockaddr;
+  socklen_t len = sizeof(sockaddr);
+  int i = 0;
+  int n = 0;
+  struct pollfd fds[NELEMS(accSockets)] = {0};
+  int accCount = 0;
+
+  for (i = 0; i < NELEMS(accSockets); i++) {
+    if (accSockets[i] == -1) {
+      break;
+    }
+    accCount++;
+    fds[i].fd = accSockets[i];
+    fds[i].events = POLLIN;
+  }
+
+  n = poll(fds, accCount, 100);
+  if (n > 0) {
+    for (i = 0; i < accCount; i++) {
+      if (fds[i].revents) {
+        client = ::accept(fds[i].fd, (struct sockaddr *)&sockaddr, &len);
+        if (client < 0) {
+          throw(SocketException(SocketException::NET_ERR_ACCEPT, errno));
         }
-        accCount++;
-        fds[i].fd = accSockets[i];
-        fds[i].events = POLLIN;
+        setOpts(client);
+        setMode(client, true);
+        break;
+      }
+    }
+  }
+
+  return client;
+}
+
+int Socket::send(const char *buf, int len) {
+  int n;
+  char *pos = NULL;
+  int left;
+
+  pos = (char *)buf;
+  left = len;
+
+  while (left > 0) {
+    n = ::send(socket, pos, left, 0);
+    if (n < 0) {
+      if ((errno == EAGAIN) || (errno == EWOULDBLOCK) || (errno == EINTR)) {
+        continue;
+      }
+      throw(SocketException(SocketException::NET_ERR_SEND, errno));
+    }
+    pos += n;
+    left -= n;
+  }
+
+  return 0;
+}
+
+int Socket::recv(char *buf, int len) {
+  int n;
+  int left;
+  char *pos;
+
+  pos = buf;
+  left = len;
+
+  while (left > 0) {
+    n = ::recv(socket, pos, left, 0);
+    if (n < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      if ((errno == EAGAIN) || (errno == EWOULDBLOCK)) {
+        break;
+      }
+      throw(SocketException(SocketException::NET_ERR_RECV, errno));
+    } else if (n == 0) {
+      throw(SocketException(SocketException::NET_ERR_CLOSED));
     }
 
-    n = poll(fds, accCount, 100);
-    if (n > 0) {
-        for (i = 0; i < accCount; i++) {
-            if (fds[i].revents) {
-                client = ::accept(fds[i].fd, (struct sockaddr *)&sockaddr, &len);
-                if (client < 0) {
-                    throw (SocketException(SocketException::NET_ERR_ACCEPT, errno));
-                }
-                setOpts(client);
-                setMode(client, true);
-                break;
-            }
-        }
-    }
+    pos += n;
+    left -= n;
+  }
 
-    return client;
+  return (len - left);
 }
 
-int Socket::send(const char *buf, int len)
-{
-    int n;
-    char *pos = NULL;
-    int left;
+void Socket::close(Socket::DIRECTION how) {
+  if (socket < 0)
+    return;
 
-    pos = (char *) buf;
-    left = len;
-
-    while (left > 0) {
-        n = ::send(socket, pos, left, 0);
-        if (n < 0) {
-            if ((errno == EAGAIN) || (errno == EWOULDBLOCK) || (errno == EINTR)) {
-                continue;
-            } 
-            throw (SocketException(SocketException::NET_ERR_SEND, errno));
-        }
-        pos += n;
-        left -= n;
-    }
-
-    return 0;
+  switch (how) {
+  case READ:
+    ::shutdown(socket, SHUT_RD);
+    break;
+  case WRITE:
+    ::shutdown(socket, SHUT_WR);
+    break;
+  case BOTH:
+    ::shutdown(socket, SHUT_RDWR);
+    ::close(socket);
+  default:
+    break;
+  }
 }
 
-int Socket::recv(char *buf, int len)
-{
-    int n;
-    int left;
-    char *pos;
+int Socket::getDisableIPv6() { return disableIpv6; }
 
-    pos = buf;
-    left    = len;
+void Socket::setDisableIPv6(int flag) { disableIpv6 = flag; }
 
-    while (left > 0) {
-        n = ::recv(socket, pos, left, 0);
-        if (n < 0) {
-            if (errno == EINTR) {
-                continue;
-            }
-            if ((errno == EAGAIN) || (errno == EWOULDBLOCK)) {
-                break;
-            }
-            throw (SocketException(SocketException::NET_ERR_RECV, errno));
-        } else if (n == 0) {
-            throw (SocketException(SocketException::NET_ERR_CLOSED));
-        }
+void Socket::setConnTimes(int cnt) { connTimes = cnt; }
 
-        pos += n;
-        left -= n;
-    }
+int Socket::numOfListenFds() { return numListenfds; }
 
-    return (len - left);
+int Socket::getListenSockfds(int *fds) {
+  int i = 0;
+  for (i = 0; i < numListenfds; i++) {
+    fds[i] = accSockets[i];
+  }
+  return i;
 }
 
-void Socket::close(Socket::DIRECTION how)
-{
-    if (socket < 0)
-        return;
-
-    switch (how) {
-        case READ:
-            ::shutdown(socket, SHUT_RD); 
-            break;
-        case WRITE:
-            ::shutdown(socket, SHUT_WR);
-            break;
-        case BOTH:
-            ::shutdown(socket, SHUT_RDWR);
-            ::close(socket);
-        default:
-            break;
-    }
-}
-
-int Socket::getDisableIPv6()
-{
-    return disableIpv6;
-}
-
-void Socket::setDisableIPv6(int flag)
-{
-    disableIpv6 =  flag;
-}
-
-void Socket::setConnTimes(int cnt)
-{
-    connTimes = cnt;
-}
-
-int Socket::numOfListenFds()
-{
-    return numListenfds;
-}
-
-int Socket::getListenSockfds(int *fds)
-{
-    int i = 0;
-    for (i = 0; i < numListenfds; i++) {
-        fds[i] = accSockets[i];
-    }
-    return i;
-}
-
-SocketException::SocketException(int code) throw()
-    : errCode(code), errNum(0)
-{
-}
+SocketException::SocketException(int code) throw() : errCode(code), errNum(0) {}
 
 SocketException::SocketException(int code, int num) throw()
-    : errCode(code), errNum(num)
-{
+    : errCode(code), errNum(num) {}
+
+int SocketException::getErrCode() const throw() { return errCode; }
+
+int SocketException::getErrNum() const throw() { return errNum; }
+
+string &SocketException::getErrMsg() throw() {
+  switch (errCode) {
+  case NET_ERR_SOCKET:
+    errMsg = "Function ::socket()";
+    break;
+  case NET_ERR_CONNECT:
+    errMsg = "Function ::connect()";
+    break;
+  case NET_ERR_GETADDRINFO:
+    errMsg = "Function ::getaddrinfo()";
+    break;
+  case NET_ERR_SEND:
+    errMsg = "Function ::send()";
+    break;
+  case NET_ERR_RECV:
+    errMsg = "Function ::recv()";
+    break;
+  case NET_ERR_FCNTL:
+    errMsg = "Function ::fcntl()";
+    break;
+  case NET_ERR_CLOSED:
+    errMsg = "Function ::recv() connection was closed by peer";
+    break;
+  case NET_ERR_DATA:
+    errMsg = "Received unexpected data";
+    break;
+  case NET_ERR_BIND:
+    errMsg = "Function ::bind()";
+  default:
+    errMsg = "Unknown error";
+    break;
+  }
+
+  if (errNum != 0) {
+    errMsg += "; system error: ";
+    errMsg += ::strerror(errNum);
+  }
+
+  return errMsg;
 }
-
-int SocketException::getErrCode() const throw()
-{
-    return errCode;
-}
-
-int SocketException::getErrNum() const throw()
-{
-    return errNum;
-}
-
-string & SocketException::getErrMsg() throw()
-{
-    switch (errCode) {
-        case NET_ERR_SOCKET:
-            errMsg = "Function ::socket()";
-            break;
-        case NET_ERR_CONNECT:
-            errMsg = "Function ::connect()";
-            break;
-        case NET_ERR_GETADDRINFO:
-            errMsg = "Function ::getaddrinfo()";
-            break;
-        case NET_ERR_SEND:
-            errMsg = "Function ::send()";
-            break;
-        case NET_ERR_RECV:
-            errMsg = "Function ::recv()";
-            break;
-        case NET_ERR_FCNTL:
-            errMsg = "Function ::fcntl()";
-            break;
-        case NET_ERR_CLOSED:
-            errMsg = "Function ::recv() connection was closed by peer";
-            break;
-        case NET_ERR_DATA:
-            errMsg = "Received unexpected data";
-            break;
-        case NET_ERR_BIND:
-            errMsg = "Function ::bind()";
-        default:
-            errMsg = "Unknown error";
-            break;
-    }
-
-    if (errNum != 0) {
-        errMsg += "; system error: ";
-        errMsg += ::strerror(errNum);
-    }
-
-    return errMsg;
-}
-

--- a/src/rpcworker.cpp
+++ b/src/rpcworker.cpp
@@ -6,12 +6,12 @@ SPDX-License-Identifier: Apache-2.0
 
 #include <unistd.h>
 
-#include "packer.hpp"
 #include "log.hpp"
+#include "packer.hpp"
 #include "rpcworker.hpp"
 
-#include <thread>
 #include <jsoncpp/json/json.h>
+#include <thread>
 
 #define CLOUDLET_PATH "/opt/cloudland/bin/cloudlet"
 #define CLOUD_HOST_FILE "/opt/cloudland/etc/host.list"
@@ -21,7 +21,8 @@ SPDX-License-Identifier: Apache-2.0
 #include "httplib.h"
 
 /*
-Status RemoteExecServiceImpl::Transmit(ServerContext* context, ServerReader<FileChunk>* reader, TransmitAck* ack)
+Status RemoteExecServiceImpl::Transmit(ServerContext* context,
+ServerReader<FileChunk>* reader, TransmitAck* ack)
 {
     FileChunk chunk;
     bool first = true;
@@ -59,9 +60,10 @@ Status RemoteExecServiceImpl::Transmit(ServerContext* context, ServerReader<File
                 return Status::OK;
             }
 
-            log_info("Transmit File: %d, control: %s, path: %s, size %lld", chunk.id(), (char *)control.c_str(), (char *)chunk.filepath().c_str(), chunk.filesize());
-            if (control.find("type=") == string::npos) {
-                control += " type=file";
+            log_info("Transmit File: %d, control: %s, path: %s, size %lld",
+chunk.id(), (char *)control.c_str(), (char *)chunk.filepath().c_str(),
+chunk.filesize()); if (control.find("type=") == string::npos) { control += "
+type=file";
             }
             first = false;
         }
@@ -87,252 +89,260 @@ Status RemoteExecServiceImpl::Transmit(ServerContext* context, ServerReader<File
 }
 */
 
-int RemoteExecServiceImpl::exec_cmd(int id, char *cmd)
-{
-    int bytes = 0;
-    FILE *fp = NULL;
-    char result[1024] = {0};
-    char command[1024] = {0};
+int RemoteExecServiceImpl::exec_cmd(int id, char *cmd) {
+  int bytes = 0;
+  FILE *fp = NULL;
+  char result[1024] = {0};
+  char command[1024] = {0};
 
-    snprintf(command, sizeof(command), "%s %s", cmd, "2>&1");
-    fp = popen(cmd, "r");
+  snprintf(command, sizeof(command), "%s %s", cmd, "2>&1");
+  fp = popen(command, "r");
+  if (fp != NULL) {
     bytes = fread(result, sizeof(char), sizeof(result) - 1, fp);
     pclose(fp);
-    log_info("Backend or agent %d responded command %s, result %s", id, cmd, result);
+  }
+  log_info("Backend or agent %d responded command %s, result %s", id, cmd,
+           result);
 
-    return 0;
+  return 0;
 }
 
-void RemoteExecServiceImpl::Execute(const Request &request, Response &response)
-{
-    Json::Reader reader;
-    Json::Value value;
-    if (!reader.parse(request.body, value)) {
-        response.status = BadRequest_400;
-        response.set_content(R"({"error": "fail to parse"})", "application/json");
-    }
-    string trace = request.get_header_value("RequestID");
-    int msgID = value["Id"].asInt();
-    int extra = value["Extra"].asInt();
-    char *control = strdup(value["Control"].asString().c_str());
-    char *command = strdup(value["Command"].asString().c_str());
-    Packer packer;
-    packer.packInt(msgID);
-    packer.packInt(extra);
-    packer.packStr(control);
-    packer.packStr(command);
-    char *inter = strstr(control, "inter=");
-    char *select = strstr(control, "select=");
-    char *group = strstr(control, "group=");
-    char *toall = strstr(control, "toall=");
-    char *mkgrp = strstr(control, "mkgrp=");
-    char *rmgrp = strstr(control, "rmgrp=");
-    char *lsgrp = strstr(control, "lsgrp=");
-    char *term = strstr(control, "term=");
-    char *callback = strstr(control, "callback");
-    char *message = packer.getPackedMsg();
-    int length = packer.getPackedMsgLen();
+void RemoteExecServiceImpl::Execute(const Request &request,
+                                    Response &response) {
+  Json::Reader reader;
+  Json::Value value;
+  if (!reader.parse(request.body, value)) {
+    response.status = BadRequest_400;
+    response.set_content(R"({"error": "fail to parse"})", "application/json");
+  }
+  string trace = request.get_header_value("RequestID");
+  int msgID = value["Id"].asInt();
+  int extra = value["Extra"].asInt();
+  char *control = strdup(value["Control"].asString().c_str());
+  char *command = strdup(value["Command"].asString().c_str());
+  bool replied = false;
+  Packer packer;
+  packer.packInt(msgID);
+  packer.packInt(extra);
+  packer.packStr(control);
+  packer.packStr(command);
+  char *inter = strstr(control, "inter=");
+  char *select = strstr(control, "select=");
+  char *group = strstr(control, "group=");
+  char *toall = strstr(control, "toall=");
+  char *mkgrp = strstr(control, "mkgrp=");
+  char *rmgrp = strstr(control, "rmgrp=");
+  char *lsgrp = strstr(control, "lsgrp=");
+  char *term = strstr(control, "term=");
+  char *callback = strstr(control, "callback");
+  char *message = packer.getPackedMsg();
+  int length = packer.getPackedMsgLen();
 
-    log_info("Received message id: %d, extra: %d, control: %s, command: %s", msgID, extra, control, command);
-    try {
-        if (inter != NULL) {
-            int node = -1;
-            char *pnode = inter + strlen("inter=");
+  log_info("Received message id: %d, extra: %d, control: %s, command: %s",
+           msgID, extra, control, command);
+  try {
+    if (inter != NULL) {
+      int node = -1;
+      char *pnode = inter + strlen("inter=");
 
-            if ((*pnode != '\0') && (*pnode != ' ')) {
-                node = atoi((const char *)pnode);
-            }
-            if (node >= 0) {
-                sciNet.sendMessage(node, message, length);
-                log_info("Message ID: %d control: %s command: %s was sent to node %d", msgID, control, command, node);
-            } else {
-                sciNet.sendMessage(message, length);
-                log_info("Message ID: %d control: %s command: %s was sent to scheduler", msgID, control, command);
-            }
-        } else if (group != NULL) {
-            log_info("Message ID: %d control: %s command: %s was sent to group", msgID, control, command);
-            char *name = group + strlen("group=");
-            char *p = strchr(group, ' ');
-            if (p != NULL) {
-                *p = '\0';
-            }
-            sciNet.sendMessage(message, length, name);
-        } else if (select != NULL) {
-            log_info("Message ID: %d control: %s command: %s was sent to group member", msgID, control, command);
-            char *desc = select + strlen("select=");
-            sciNet.createGroup(desc);
-            char *p = strchr(select, ':');
-            if (p != NULL) {
-                *p = '\0';
-            }
-	    char *name = desc;
-            sciNet.sendMessage(message, length, name, true);
-        } else if (toall != NULL) {
-            log_info("Message ID: %d control: %s command: %s was sent to all", msgID, control, command);
-            char *name = toall + strlen("toall=");
-            char *p = strchr(name, ' ');
-            if (p != NULL) {
-                *p = '\0';
-            }
-            if (strcmp(name, "agent") == 0) {
-                sciNet.sendMessage(message, length, name);
-            } else {
-                sciNet.groupMessage(message, length, name);
-            }
-        } else if (mkgrp != NULL) {
-            char *desc = mkgrp + strlen("mkgrp=");
-            sciNet.createGroup(desc);
-        } else if (rmgrp != NULL) {
-            char *name = rmgrp + strlen("rmgrp=");
-            sciNet.freeGroup(name);
-        } else if (lsgrp != NULL) {
-            string groupStr = sciNet.listGroup();
-	    string content = R"({"groups": )" + groupStr + "}";
-            response.set_content(content, "application/json");
-	    return;
-        } else if (term != NULL) {
-            running = false;
-        } else if (callback != NULL) {
-            exec_cmd(extra, command);
-        } else {
-            response.status = NotFound_404;
-	    response.set_content(R"({"status": "Not Found"})", "application/json");
-	    return;
-        }
-    } catch (CommonException &e) {
-        log_error(e.getErrMsg());
+      if ((*pnode != '\0') && (*pnode != ' ')) {
+        node = atoi((const char *)pnode);
+      }
+      if (node >= 0) {
+        sciNet.sendMessage(node, message, length);
+        log_info("Message ID: %d control: %s command: %s was sent to node %d",
+                 msgID, control, command, node);
+      } else {
+        sciNet.sendMessage(message, length);
+        log_info("Message ID: %d control: %s command: %s was sent to scheduler",
+                 msgID, control, command);
+      }
+    } else if (group != NULL) {
+      log_info("Message ID: %d control: %s command: %s was sent to group",
+               msgID, control, command);
+      char *name = group + strlen("group=");
+      char *p = strchr(group, ' ');
+      if (p != NULL) {
+        *p = '\0';
+      }
+      sciNet.sendMessage(message, length, name);
+    } else if (select != NULL) {
+      log_info(
+          "Message ID: %d control: %s command: %s was sent to group member",
+          msgID, control, command);
+      char *desc = select + strlen("select=");
+      sciNet.createGroup(desc);
+      char *p = strchr(select, ':');
+      if (p != NULL) {
+        *p = '\0';
+      }
+      char *name = desc;
+      sciNet.sendMessage(message, length, name, true);
+    } else if (toall != NULL) {
+      log_info("Message ID: %d control: %s command: %s was sent to all", msgID,
+               control, command);
+      char *name = toall + strlen("toall=");
+      char *p = strchr(name, ' ');
+      if (p != NULL) {
+        *p = '\0';
+      }
+      if (strcmp(name, "agent") == 0) {
+        sciNet.sendMessage(message, length, name);
+      } else {
+        sciNet.groupMessage(message, length, name);
+      }
+    } else if (mkgrp != NULL) {
+      char *desc = mkgrp + strlen("mkgrp=");
+      sciNet.createGroup(desc);
+    } else if (rmgrp != NULL) {
+      char *name = rmgrp + strlen("rmgrp=");
+      sciNet.freeGroup(name);
+    } else if (lsgrp != NULL) {
+      string groupStr = sciNet.listGroup();
+      string content = R"({"groups": )" + groupStr + "}";
+      response.set_content(content, "application/json");
+      replied = true;
+    } else if (term != NULL) {
+      running = false;
+    } else if (callback != NULL) {
+      exec_cmd(extra, command);
+    } else {
+      response.status = NotFound_404;
+      response.set_content(R"({"status": "Not Found"})", "application/json");
+      replied = true;
     }
+  } catch (CommonException &e) {
+    log_error(e.getErrMsg());
+  }
+  free(control);
+  free(command);
+  if (!replied) {
     response.set_content(R"({"status": "OK"})", "application/json");
+  }
 }
 
 FrontBack::FrontBack(string rHost, int rPort)
-	: remoteHost(rHost), remotePort(rPort)
-{
+    : remoteHost(rHost), remotePort(rPort) {}
+
+void FrontBack::ExecuteAsync(int msg_id, int extra, char *ctl, char *cmd,
+                             char *trace) {
+  ctl = strdup(ctl);
+  cmd = strdup(cmd);
+  trace = strdup(trace);
+  threadpool.AddJob([this, msg_id, extra, ctl, cmd, trace]() {
+    string reply = this->Execute(msg_id, extra, ctl, cmd, trace);
+    free(ctl);
+    free(cmd);
+    free(trace);
+    log_info("rpc_replied %s", reply.c_str());
+  });
 }
 
-void FrontBack::ExecuteAsync(int msg_id, int extra, char *ctl, char *cmd, char *trace)
-{
-    ctl = strdup(ctl);
-    cmd = strdup(cmd);
-    trace = strdup(trace);
-    threadpool.AddJob( [this, msg_id, extra, ctl, cmd, trace](){
-            string reply = this->Execute(msg_id, extra, ctl, cmd, trace);
-            free(ctl);
-            free(cmd);
-            free(trace);
-            log_info("rpc_replied %s", reply.c_str());
-        });
+string FrontBack::Execute(int msg_id, int extra, char *ctl, char *cmd,
+                          char *trace) {
+  Json::Value content;
+  Json::StreamWriterBuilder writerBuilder;
+  ostringstream cstream;
+  unique_ptr<Json::StreamWriter> jsonWriter(writerBuilder.newStreamWriter());
+
+  content["id"] = msg_id;
+  content["extra"] = extra;
+  content["control"] = ctl;
+  content["command"] = cmd;
+  jsonWriter->write(content, &cstream);
+
+  httplib::Client cli(remoteHost, remotePort);
+  //    cli.enable_server_certificate_verification(false);
+  auto res = cli.Post("/internal/execute", cstream.str(), "application/json");
+  if (res.error() != httplib::Error::Success) {
+    string errMsg = "Failed to call RPC";
+    log_info("Failed to call RPC, status: %d", res.error());
+    return errMsg;
+  }
+  Json::Reader reader;
+  Json::Value value;
+  if ((res->status != OK_200) || (!reader.parse(res->body, value))) {
+    string errMsg = "Failed to parse response body";
+    log_info("Failed to parse response body, status: %d, body: %s", res->status,
+             res->body);
+    return errMsg;
+  }
+  string status = value["status"].asString();
+  return status;
 }
 
-string FrontBack::Execute(int msg_id, int extra, char *ctl, char *cmd, char *trace)
-{
-    Json::Value content;
-    Json::StreamWriterBuilder writerBuilder;
-    ostringstream cstream;
-    unique_ptr<Json::StreamWriter> jsonWriter(writerBuilder.newStreamWriter());
+RemoteExecServiceImpl::RemoteExecServiceImpl(NetLayer &sci)
+    : sciNet(sci), running(true) {}
 
-    content["id"] = msg_id;
-    content["extra"] = extra;
-    content["control"] = ctl;
-    content["command"] = cmd;
-    jsonWriter->write(content, &cstream);
-
-    httplib::Client cli(remoteHost, remotePort);
-//    cli.enable_server_certificate_verification(false);
-    auto res = cli.Post("/internal/execute", cstream.str(), "application/json");
-    if (res.error() != httplib::Error::Success) {
-            string errMsg = "Failed to call RPC";
-            log_info("Failed to call RPC, status: %d", res.error());
-            return errMsg;
-    }
-    Json::Reader reader;
-    Json::Value value;
-    if ((res->status != OK_200) || (!reader.parse(res->body, value))) {
-        string errMsg = "Failed to parse response body";
-        log_info("Failed to parse response body, status: %d, body: %s", res->status, res->body);
-        return errMsg;
-    }
-    string status = value["status"].asString();
-    return status;
-}
-
-RemoteExecServiceImpl::RemoteExecServiceImpl(NetLayer & sci)
-    : sciNet(sci), running(true)
-{
-}
-
-RpcWorker::RpcWorker()
-    : rpcClient(NULL)
-{
-    initConn();
-}
+RpcWorker::RpcWorker() : rpcClient(NULL) { initConn(); }
 
 void RpcWorker::initConn() {
-    char *envp = getenv("RPC_REMOTE_ENDPOINT");
-    if (envp == NULL) {
-        envp = RPC_REMOTE_ENDPOINT;
-    }
-    if (rpcClient != NULL) {
-        delete rpcClient;
-    }
-    char *endpoint = strdup(envp);
-    string remoteHost = "localhost";
-    int remotePort = 50050;
-    char *token = strchr(endpoint, ':');
-    if (token != NULL) {
-        *token = '\0';
-	remoteHost = endpoint;
-	remotePort = atoi(token + 1);
-    }
-    
-    rpcClient = new FrontBack(remoteHost, remotePort);
+  char *envp = getenv("RPC_REMOTE_ENDPOINT");
+  if (envp == NULL) {
+    envp = RPC_REMOTE_ENDPOINT;
+  }
+  if (rpcClient != NULL) {
+    delete rpcClient;
+  }
+  char *endpoint = strdup(envp);
+  string remoteHost = "localhost";
+  int remotePort = 50050;
+  char *token = strchr(endpoint, ':');
+  if (token != NULL) {
+    *token = '\0';
+    remoteHost = endpoint;
+    remotePort = atoi(token + 1);
+  }
+
+  rpcClient = new FrontBack(remoteHost, remotePort);
+  free(endpoint);
 }
 
-RpcWorker::~RpcWorker()
-{
-    if (rpcClient != NULL) {
-        delete rpcClient;
-    }
+RpcWorker::~RpcWorker() {
+  if (rpcClient != NULL) {
+    delete rpcClient;
+  }
 }
 
-void RpcWorker::runServer()
-{
-    char *bePath = getenv("CLOUDLET_PATH");
-    char *hFile = getenv("CLOUD_HOST_FILE");
-    if (bePath == NULL) {
-        bePath = CLOUDLET_PATH;
-    }
-    if (hFile == NULL) {
-        hFile = CLOUD_HOST_FILE;
-    }
+void RpcWorker::runServer() {
+  char *bePath = getenv("CLOUDLET_PATH");
+  char *hFile = getenv("CLOUD_HOST_FILE");
+  if (bePath == NULL) {
+    bePath = CLOUDLET_PATH;
+  }
+  if (hFile == NULL) {
+    hFile = CLOUD_HOST_FILE;
+  }
 
-    string serverAddress = "localhost";
-    int serverPort = 50051;
-    char *sAddr = getenv("RPC_SERVER_ENDPOINT");
-    if (sAddr == NULL) {
-        sAddr = RPC_SERVER_ENDPOINT;
-    }
-    char *endpoint = strdup(sAddr);
-    char *token = strchr(endpoint, ':');
-    if (token != NULL) {
-        *token = '\0';
-	serverAddress = endpoint;
-	serverPort = atoi(token + 1);
-    }
-    Server http;
-    RemoteExecServiceImpl *service = new RemoteExecServiceImpl(sciNet);
-    http.Post("/internal/execute", [service](const Request &req, Response &res) {
-        service->Execute(req, res);
-    });
-    auto httpThread = std::thread([&]() { http.listen(serverAddress, serverPort); });
+  string serverAddress = "localhost";
+  int serverPort = 50051;
+  char *sAddr = getenv("RPC_SERVER_ENDPOINT");
+  if (sAddr == NULL) {
+    sAddr = RPC_SERVER_ENDPOINT;
+  }
+  char *endpoint = strdup(sAddr);
+  char *token = strchr(endpoint, ':');
+  if (token != NULL) {
+    *token = '\0';
+    serverAddress = endpoint;
+    serverPort = atoi(token + 1);
+  }
+  free(endpoint);
+  Server http;
+  RemoteExecServiceImpl *service = new RemoteExecServiceImpl(sciNet);
+  http.Post("/internal/execute", [service](const Request &req, Response &res) {
+    service->Execute(req, res);
+  });
+  auto httpThread =
+      std::thread([&]() { http.listen(serverAddress, serverPort); });
 
-    try {
-        sciNet.initFE(bePath, hFile, this);
-    } catch (CommonException &e) {
-        log_error(e.getErrMsg());
-    }
+  try {
+    sciNet.initFE(bePath, hFile, this);
+  } catch (CommonException &e) {
+    log_error(e.getErrMsg());
+  }
 
-    httpThread.join();
-    sciNet.terminate();
-    log_info("RPC worker terminated normally");
+  httpThread.join();
+  sciNet.terminate();
+  log_info("RPC worker terminated normally");
 }

--- a/web/src/model/model.go
+++ b/web/src/model/model.go
@@ -27,9 +27,9 @@ type Model struct {
 	CreatedAt time.Time
 	UpdatedAt time.Time
 	DeletedAt *time.Time    `gorm:"index"`
-	UUID      string        `gorm:"type:varchar(64)","index"`
+	UUID      string        `gorm:"type:varchar(64);index"`
 	Creater   int64         `gorm:"default:1"` /* The user ID of the resource */
-	OwnerInfo *Organization `gorm:"PRELOAD:false","foreignkey:Owner"`
+	OwnerInfo *Organization `gorm:"PRELOAD:false;foreignkey:Owner"`
 }
 
 func (m *Model) BeforeCreate() (err error) {

--- a/web/src/model/volume.go
+++ b/web/src/model/volume.go
@@ -52,7 +52,7 @@ const (
 
 type Volume struct {
 	Model
-	Owner int64  `gorm:"default:1","index"` /* The organization ID of the resource */
+	Owner int64  `gorm:"default:1;index"` /* The organization ID of the resource */
 	Name  string `gorm:"type:varchar(128)"`
 	/*
 		The path of the volume, format is:
@@ -138,10 +138,10 @@ func (v *Volume) GetOriginVolumeID() string {
 
 type VolumeBackup struct {
 	Model
-	Owner      int64  `gorm:"default:1;index"` /* The organization ID of the resource */
-	Name       string `gorm:"type:varchar(128)"`
-	VolumeID   int64
-	Volume     *Volume      `gorm:"foreignkey:VolumeID;index"`
+	Owner      int64        `gorm:"default:1;index"` /* The organization ID of the resource */
+	Name       string       `gorm:"type:varchar(128)"`
+	VolumeID   int64        `gorm:"index"`
+	Volume     *Volume      `gorm:"foreignkey:VolumeID"`
 	BackupType string       `gorm:"type:varchar(32);index"` // snapshot or backup
 	Status     BackupStatus `gorm:"type:varchar(32)"`
 	Size       int32


### PR DESCRIPTION
- rpcworker.cpp: fix wrong variable passed to popen() (cmd -> command), add NULL check before fread/pclose, free strdup'd control/command/endpoint pointers, add replied flag to prevent duplicate responses
- model.go, volume.go: fix GORM tag separator from comma to semicolon
- socket.cpp: reorder includes alphabetically, unify code style (2-space indent)