### PR TITLE
PET-1411 update ansible scripts to support scrapting exporter volume …

### DIFF
--- a/deploy/roles/monitor/tasks/main.yml
+++ b/deploy/roles/monitor/tasks/main.yml
@@ -2,7 +2,6 @@
   set_fact:
     scrape_interval: 30
     alarm_rules_manager_port: 8256
-    monitor_enable_cloudland_global_service_metrics: "{{ enable_cloudland_global_service_metrics | default(false) }}"
 
 - name: Set prometheus_server_ip from monitor group
   set_fact:
@@ -53,9 +52,9 @@
 - name: Generate CloudLand exporters config block
   set_fact:
     cloudland_exporters_block: |
-      - job_name: 'clexporter-cloudland'
+      - job_name: 'clexporter'
         scrape_interval: 60s
-        metrics_path: '/metrics/cloudland'
+        metrics_path: '/metrics'
         scrape_timeout: 30s
         honor_labels: true
         file_sd_configs:
@@ -69,16 +68,6 @@
         file_sd_configs:
           - files: ['/etc/prometheus/lists/cloudland_exporters.json']
             refresh_interval: 30s
-      {% if monitor_enable_cloudland_global_service_metrics | bool %}
-      - job_name: 'clexporter-global-service'
-        scrape_interval: 60s
-        metrics_path: '/metrics/global-service'
-        scrape_timeout: 20s
-        honor_labels: true
-        file_sd_configs:
-          - files: ['/etc/prometheus/lists/cloudland_exporters.json']
-            refresh_interval: 30s
-      {% endif %}
 
 - name: Validate Alertmanager variables
   fail:

--- a/deploy/roles/monitor/tasks/main.yml
+++ b/deploy/roles/monitor/tasks/main.yml
@@ -2,6 +2,7 @@
   set_fact:
     scrape_interval: 30
     alarm_rules_manager_port: 8256
+    monitor_enable_cloudland_global_service_metrics: "{{ enable_cloudland_global_service_metrics | default(false) }}"
 
 - name: Set prometheus_server_ip from monitor group
   set_fact:
@@ -52,11 +53,32 @@
 - name: Generate CloudLand exporters config block
   set_fact:
     cloudland_exporters_block: |
-      - job_name: 'cloudland_exporter'
+      - job_name: 'clexporter-cloudland'
         scrape_interval: 60s
+        metrics_path: '/metrics/cloudland'
+        scrape_timeout: 30s
+        honor_labels: true
         file_sd_configs:
           - files: ['/etc/prometheus/lists/cloudland_exporters.json']
             refresh_interval: 30s
+      - job_name: 'clexporter-volume'
+        scrape_interval: 60s
+        metrics_path: '/metrics/cloudland/volume'
+        scrape_timeout: 20s
+        honor_labels: true
+        file_sd_configs:
+          - files: ['/etc/prometheus/lists/cloudland_exporters.json']
+            refresh_interval: 30s
+      {% if monitor_enable_cloudland_global_service_metrics | bool %}
+      - job_name: 'clexporter-global-service'
+        scrape_interval: 60s
+        metrics_path: '/metrics/global-service'
+        scrape_timeout: 20s
+        honor_labels: true
+        file_sd_configs:
+          - files: ['/etc/prometheus/lists/cloudland_exporters.json']
+            refresh_interval: 30s
+      {% endif %}
 
 - name: Validate Alertmanager variables
   fail:

--- a/deploy/roles/monitor/tasks/main.yml
+++ b/deploy/roles/monitor/tasks/main.yml
@@ -52,7 +52,7 @@
 - name: Generate CloudLand exporters config block
   set_fact:
     cloudland_exporters_block: |
-      - job_name: 'clexporter'
+      - job_name: 'cloudland_exporter'
         scrape_interval: 60s
         metrics_path: '/metrics'
         scrape_timeout: 30s
@@ -60,7 +60,7 @@
         file_sd_configs:
           - files: ['/etc/prometheus/lists/cloudland_exporters.json']
             refresh_interval: 30s
-      - job_name: 'clexporter-volume'
+      - job_name: 'cloudland_volume_exporter'
         scrape_interval: 60s
         metrics_path: '/metrics/cloudland/volume'
         scrape_timeout: 20s

--- a/deploy/roles/monitor_cland/tasks/main.yml
+++ b/deploy/roles/monitor_cland/tasks/main.yml
@@ -128,6 +128,11 @@
         cloudland_rest_port: "8255"
         cloudland_admin_user: "admin"
         cloudland_admin_password: "{{ admin_passwd }}"
+        wds_endpoint: "{{ wds_address | default('') }}"
+        wds_host: "{{ (wds_address | regex_replace('^https?://', '') | regex_replace('/.*$', '') | regex_replace(':\\d+$', '')) if (wds_address is defined and (wds_address | length) > 0) else '' }}"
+        wds_port: "{{ wds_monitor_access_port | default('9090') }}"
+        wds_username: "{{ wds_admin | default('') }}"
+        wds_password: "{{ wds_pass | default('') }}"
         exporter_image: "reg-staging.raksmart.com:8443/petacloud/petacloud-exporter"
         exporter_image_tag: "latest"
         cloudland_exporter_port: 9102
@@ -209,7 +214,7 @@
     # ------------------------------------------------------------------------
     - name: Wait for exporter to be ready
       uri:
-        url: "http://localhost:{{ cloudland_exporter_port }}/metrics"
+        url: "http://localhost:{{ cloudland_exporter_port }}/metrics/cloudland"
         method: GET
         status_code: 200
         timeout: 5
@@ -220,7 +225,7 @@
       ignore_errors: true
 
     - name: Verify exporter is exposing CloudLand metrics
-      shell: "curl -s http://localhost:{{ cloudland_exporter_port }}/metrics | grep -q cloudland_hypervisor_scrape_success"
+      shell: "curl -s http://localhost:{{ cloudland_exporter_port }}/metrics/cloudland | grep -q cloudland_hypervisor_scrape_success"
       register: metrics_check
       changed_when: false
       failed_when: false

--- a/deploy/roles/monitor_cland/tasks/main.yml
+++ b/deploy/roles/monitor_cland/tasks/main.yml
@@ -214,7 +214,7 @@
     # ------------------------------------------------------------------------
     - name: Wait for exporter to be ready
       uri:
-        url: "http://localhost:{{ cloudland_exporter_port }}/metrics/cloudland"
+        url: "http://localhost:{{ cloudland_exporter_port }}/metrics"
         method: GET
         status_code: 200
         timeout: 5
@@ -225,7 +225,7 @@
       ignore_errors: true
 
     - name: Verify exporter is exposing CloudLand metrics
-      shell: "curl -s http://localhost:{{ cloudland_exporter_port }}/metrics/cloudland | grep -q cloudland_hypervisor_scrape_success"
+      shell: "curl -s http://localhost:{{ cloudland_exporter_port }}/metrics | grep -q cloudland_hypervisor_scrape_success"
       register: metrics_check
       changed_when: false
       failed_when: false

--- a/deploy/roles/monitor_cland/templates/clexporter.yaml.j2
+++ b/deploy/roles/monitor_cland/templates/clexporter.yaml.j2
@@ -32,7 +32,7 @@ RPCSvc:
         # Log Level: The level at which to log. This accepts logging specifications
         # Valid Levels: "CRITICAL", "ERROR", "WARNING", "NOTICE", "INFO", "DEBUG"
         Log:
-            LogFile: ./clexporter.log
+            LogFile: ./logs/clexporter.log
             # Log Level: The level at which to log. This accepts logging specifications
             # Valid Levels: "CRITICAL", "ERROR", "WARNING", "NOTICE", "INFO", "DEBUG"
             LogLevel: debug
@@ -48,7 +48,7 @@ RPCSvc:
         Profile:
             Enabled: false
             Address: 0.0.0.0:6060
-DebugMode: true
+DebugMode: false
 
 # CloudLand Exporter Configuration
 CloudLand:
@@ -68,3 +68,34 @@ CloudLand:
         Timeout: 30
         # Scrape interval for metrics collection in seconds
         ScrapeInterval: 60
+    # WDS Configuration
+    WDS:
+        # WDS API endpoint from netconf.yml
+        Endpoint: "{{ wds_endpoint }}"
+        # WDS host parsed from endpoint (e.g. https://10.9.8.99 -> 10.9.8.99)
+        Host: "{{ wds_host }}"
+        # WDS monitor access port
+        Port: "{{ wds_port }}"
+        # WDS API username
+        Username: "{{ wds_username }}"
+        # WDS API password
+        Password: "{{ wds_password }}"
+        # Optional persistent version file path for volume snapshot sequence
+        # Default: /opt/petacloud-exporter/logs/volume_snapshot.version (inside container)
+        VersionFilePath: ""
+        # HTTP timeout in seconds for WDS API/Prometheus requests
+        TimeoutSeconds: 8
+        # Cache TTL in seconds for volume_wds_id -> volume_name
+        VolumeNameCacheTTLSeconds: 600
+        # Max concurrent requests when converting volume_wds_id to volume_name
+        MaxConcurrentResolve: 10
+        # Batch size for one WDS Prometheus query (effective range: 50~100, values are clamped)
+        QueryBatchSize: 100
+        # Scheme for WDS Prometheus queries (http or https) 
+        # If Prometheus TLS is enabled, this should be set to https
+        PrometheusScheme: "http"
+        # Prometheus query_range step in seconds for IOPS/throughput/latency queries.
+        # Capacity queries use 2x this value. Default: 15.
+        PrometheusStepSeconds: 15
+        # Max duration in seconds for one collection cycle (0 = auto: 90% of scrape interval)
+        MaxCollectDurationSeconds: 0

--- a/deploy/roles/vmagent/tasks/main.yml
+++ b/deploy/roles/vmagent/tasks/main.yml
@@ -13,7 +13,6 @@
     vmagent_base_dir: "/opt/vmagent"
     vmagent_scrape_interval: "30s"
     vmagent_scrape_timeout: "20s"
-    vmagent_enable_cloudland_global_service_metrics: "{{ enable_cloudland_global_service_metrics | default(false) }}"
   tags: [vmagent, vmagent_install, vmagent_sd_update]
 
 # ============================================

--- a/deploy/roles/vmagent/tasks/main.yml
+++ b/deploy/roles/vmagent/tasks/main.yml
@@ -13,6 +13,7 @@
     vmagent_base_dir: "/opt/vmagent"
     vmagent_scrape_interval: "30s"
     vmagent_scrape_timeout: "20s"
+    vmagent_enable_cloudland_global_service_metrics: "{{ enable_cloudland_global_service_metrics | default(false) }}"
   tags: [vmagent, vmagent_install, vmagent_sd_update]
 
 # ============================================

--- a/deploy/roles/vmagent/templates/relabel_rules.yml.j2
+++ b/deploy/roles/vmagent/templates/relabel_rules.yml.j2
@@ -1,5 +1,5 @@
 - source_labels: [__name__]
-  regex: '^(up|libvirt_.*|domain_north_south_.*|node_.*|conntrack_.*|vm_interface_bandwidth_config_mbps|vm_instance_map)$'
+  regex: '^(up|libvirt_.*|domain_north_south_.*|node_.*|conntrack_.*|vm_interface_bandwidth_config_mbps|vm_instance_map|cloudland_volume_.*|global_service_.*)$'
   action: keep
 - source_labels: [__name__]
   regex: '^libvirt_domain_block_meta$'

--- a/deploy/roles/vmagent/templates/relabel_rules.yml.j2
+++ b/deploy/roles/vmagent/templates/relabel_rules.yml.j2
@@ -1,5 +1,5 @@
 - source_labels: [__name__]
-  regex: '^(up|libvirt_.*|domain_north_south_.*|node_.*|conntrack_.*|vm_interface_bandwidth_config_mbps|vm_instance_map|cloudland_volume_.*|global_service_.*)$'
+  regex: '^(up|libvirt_.*|domain_north_south_.*|node_.*|conntrack_.*|vm_interface_bandwidth_config_mbps|vm_instance_map|cloudland_volume_.*)$'
   action: keep
 - source_labels: [__name__]
   regex: '^libvirt_domain_block_meta$'

--- a/deploy/roles/vmagent/templates/vmagent.yml.j2
+++ b/deploy/roles/vmagent/templates/vmagent.yml.j2
@@ -4,9 +4,9 @@ global:
 
 scrape_configs:
   # 1. CloudLand Exporter (Control/Management nodes)
-  - job_name: 'clexporter-cloudland'
+  - job_name: 'clexporter'
     scrape_interval: 60s
-    metrics_path: '/metrics/cloudland'
+    metrics_path: '/metrics'
     scrape_timeout: 30s
     honor_labels: true
     file_sd_configs:
@@ -20,17 +20,6 @@ scrape_configs:
     honor_labels: true
     file_sd_configs:
       - files: ['{{ vmagent_base_dir }}/sd_configs/cloudland_nodes.json']
-
-  # 1.2 CloudLand Exporter Global Service Metrics
-  {% if vmagent_enable_cloudland_global_service_metrics | bool %}
-  - job_name: 'clexporter-global-service'
-    scrape_interval: 60s
-    metrics_path: '/metrics/global-service'
-    scrape_timeout: 20s
-    honor_labels: true
-    file_sd_configs:
-      - files: ['{{ vmagent_base_dir }}/sd_configs/cloudland_nodes.json']
-  {% endif %}
 
   # 2. Libvirt Exporters (Compute/Hyper nodes)
   - job_name: 'prometheus_libvirt_exporter'

--- a/deploy/roles/vmagent/templates/vmagent.yml.j2
+++ b/deploy/roles/vmagent/templates/vmagent.yml.j2
@@ -4,7 +4,7 @@ global:
 
 scrape_configs:
   # 1. CloudLand Exporter (Control/Management nodes)
-  - job_name: 'clexporter'
+  - job_name: 'cloudland_exporter'
     scrape_interval: 60s
     metrics_path: '/metrics'
     scrape_timeout: 30s
@@ -13,7 +13,7 @@ scrape_configs:
       - files: ['{{ vmagent_base_dir }}/sd_configs/cloudland_nodes.json']
 
   # 1.1 CloudLand Exporter Volume Metrics (dedicated endpoint)
-  - job_name: 'clexporter-volume'
+  - job_name: 'cloudland_volume_exporter'
     scrape_interval: 60s
     metrics_path: '/metrics/cloudland/volume'
     scrape_timeout: 20s

--- a/deploy/roles/vmagent/templates/vmagent.yml.j2
+++ b/deploy/roles/vmagent/templates/vmagent.yml.j2
@@ -4,10 +4,33 @@ global:
 
 scrape_configs:
   # 1. CloudLand Exporter (Control/Management nodes)
-  - job_name: 'cloudland_exporter'
+  - job_name: 'clexporter-cloudland'
     scrape_interval: 60s
+    metrics_path: '/metrics/cloudland'
+    scrape_timeout: 30s
+    honor_labels: true
     file_sd_configs:
       - files: ['{{ vmagent_base_dir }}/sd_configs/cloudland_nodes.json']
+
+  # 1.1 CloudLand Exporter Volume Metrics (dedicated endpoint)
+  - job_name: 'clexporter-volume'
+    scrape_interval: 60s
+    metrics_path: '/metrics/cloudland/volume'
+    scrape_timeout: 20s
+    honor_labels: true
+    file_sd_configs:
+      - files: ['{{ vmagent_base_dir }}/sd_configs/cloudland_nodes.json']
+
+  # 1.2 CloudLand Exporter Global Service Metrics
+  {% if vmagent_enable_cloudland_global_service_metrics | bool %}
+  - job_name: 'clexporter-global-service'
+    scrape_interval: 60s
+    metrics_path: '/metrics/global-service'
+    scrape_timeout: 20s
+    honor_labels: true
+    file_sd_configs:
+      - files: ['{{ vmagent_base_dir }}/sd_configs/cloudland_nodes.json']
+  {% endif %}
 
   # 2. Libvirt Exporters (Compute/Hyper nodes)
   - job_name: 'prometheus_libvirt_exporter'


### PR DESCRIPTION
https://jira.raksmart.com:8443/browse/PET-1411
It targets to update vmagent.yml, clexporter.yml, prometheus.yml, etc. when running the ansible scripts to deploy cloudland all-in-one environment.
1.  ansible tasks for vmagent.yml /relabel-rules changes  
2.  ansible tasks for prometheus.yml changes
3.  ansible tasks for clexporter.yml changes