### PR TITLE
Pet 1539 support clear_vm event notification

### DIFF
--- a/web/src/callback/metadata.go
+++ b/web/src/callback/metadata.go
@@ -85,11 +85,6 @@ var commandMetadataRegistry = map[string]*ResourceMetadata{
 		IDArgIndex:   2,
 		ActionType:   ActionDetached,
 	},
-	"delete_volume": {
-		ResourceType: ResourceTypeVolume,
-		IDArgIndex:   1,
-		ActionType:   ActionDeleted,
-	},
 	"resize_volume": {
 		ResourceType: ResourceTypeVolume,
 		IDArgIndex:   1,
@@ -204,7 +199,7 @@ func defaultExtractor(ctx context.Context, metadata *ResourceMetadata, args []st
 	case ResourceTypeInstance:
 		return extractInstanceInfo(db, resourceID, metadata.ActionType == ActionDeleted)
 	case ResourceTypeVolume:
-		return extractVolumeInfo(db, resourceID, metadata.ActionType == ActionDeleted)
+		return extractVolumeInfo(db, resourceID)
 	case ResourceTypeImage:
 		return extractImageInfo(db, resourceID)
 	case ResourceTypeInterface:
@@ -279,18 +274,14 @@ func extractInstanceInfo(db *gorm.DB, resourceID int64, unscoped bool) (*Resourc
 	}, nil
 }
 
-func extractVolumeInfo(db *gorm.DB, resourceID int64, unscoped bool) (*ResourceChangeEvent, error) {
+func extractVolumeInfo(db *gorm.DB, resourceID int64) (*ResourceChangeEvent, error) {
 	traceID := fmt.Sprintf("vol-%d-%d", resourceID, time.Now().UnixNano())
 	start := time.Now()
 
 	row := &VolumeRow{}
-	logger.Debugf("[%s] extractVolumeInfo: unscoped=%v sql=%s args=[%d]", traceID, unscoped, compactSQL(sqlSelectVolumeByID), resourceID)
+	logger.Debugf("[%s] extractVolumeInfo: sql=%s args=[%d]", traceID, compactSQL(sqlSelectVolumeByID), resourceID)
 
-	query := db
-	if unscoped {
-		query = db.Unscoped()
-	}
-	if err := query.Raw(sqlSelectVolumeByID, resourceID).Scan(row).Error; err != nil {
+	if err := db.Raw(sqlSelectVolumeByID, resourceID).Scan(row).Error; err != nil {
 		logger.Errorf("[%s] extractVolumeInfo: query failed id=%d err=%v elapsed=%s",
 			traceID, resourceID, err, time.Since(start))
 		return nil, err

--- a/web/src/callback/metadata.go
+++ b/web/src/callback/metadata.go
@@ -43,6 +43,11 @@ var commandMetadataRegistry = map[string]*ResourceMetadata{
 		IDArgIndex:   1,
 		ActionType:   ActionStateChanged,
 	},
+	"clear_vm": {
+		ResourceType: ResourceTypeInstance,
+		IDArgIndex:   1,
+		ActionType:   ActionDeleted,
+	},
 	"migrate_vm": {
 		ResourceType: ResourceTypeInstance,
 		IDArgIndex:   3,
@@ -79,6 +84,11 @@ var commandMetadataRegistry = map[string]*ResourceMetadata{
 		ResourceType: ResourceTypeVolume,
 		IDArgIndex:   2,
 		ActionType:   ActionDetached,
+	},
+	"delete_volume": {
+		ResourceType: ResourceTypeVolume,
+		IDArgIndex:   1,
+		ActionType:   ActionDeleted,
 	},
 	"resize_volume": {
 		ResourceType: ResourceTypeVolume,
@@ -192,9 +202,9 @@ func defaultExtractor(ctx context.Context, metadata *ResourceMetadata, args []st
 
 	switch metadata.ResourceType {
 	case ResourceTypeInstance:
-		return extractInstanceInfo(db, resourceID)
+		return extractInstanceInfo(db, resourceID, metadata.ActionType == ActionDeleted)
 	case ResourceTypeVolume:
-		return extractVolumeInfo(db, resourceID)
+		return extractVolumeInfo(db, resourceID, metadata.ActionType == ActionDeleted)
 	case ResourceTypeImage:
 		return extractImageInfo(db, resourceID)
 	case ResourceTypeInterface:
@@ -218,14 +228,18 @@ func compactSQL(s string) string {
 
 // --------------------- Extractors for different resource types (Raw + join org uuid) ---------------------
 
-func extractInstanceInfo(db *gorm.DB, resourceID int64) (*ResourceChangeEvent, error) {
+func extractInstanceInfo(db *gorm.DB, resourceID int64, unscoped bool) (*ResourceChangeEvent, error) {
 	traceID := fmt.Sprintf("inst-%d-%d", resourceID, time.Now().UnixNano())
 	start := time.Now()
 
 	row := &InstanceRow{}
-	logger.Debugf("[%s] extractInstanceInfo: sql=%s args=[%d]", traceID, compactSQL(sqlSelectInstanceByID), resourceID)
+	logger.Debugf("[%s] extractInstanceInfo: unscoped=%v sql=%s args=[%d]", traceID, unscoped, compactSQL(sqlSelectInstanceByID), resourceID)
 
-	if err := db.Raw(sqlSelectInstanceByID, resourceID).Scan(row).Error; err != nil {
+	query := db
+	if unscoped {
+		query = db.Unscoped()
+	}
+	if err := query.Raw(sqlSelectInstanceByID, resourceID).Scan(row).Error; err != nil {
 		logger.Errorf("[%s] extractInstanceInfo: query failed id=%d err=%v elapsed=%s",
 			traceID, resourceID, err, time.Since(start))
 		return nil, err
@@ -265,14 +279,18 @@ func extractInstanceInfo(db *gorm.DB, resourceID int64) (*ResourceChangeEvent, e
 	}, nil
 }
 
-func extractVolumeInfo(db *gorm.DB, resourceID int64) (*ResourceChangeEvent, error) {
+func extractVolumeInfo(db *gorm.DB, resourceID int64, unscoped bool) (*ResourceChangeEvent, error) {
 	traceID := fmt.Sprintf("vol-%d-%d", resourceID, time.Now().UnixNano())
 	start := time.Now()
 
 	row := &VolumeRow{}
-	logger.Debugf("[%s] extractVolumeInfo: sql=%s args=[%d]", traceID, compactSQL(sqlSelectVolumeByID), resourceID)
+	logger.Debugf("[%s] extractVolumeInfo: unscoped=%v sql=%s args=[%d]", traceID, unscoped, compactSQL(sqlSelectVolumeByID), resourceID)
 
-	if err := db.Raw(sqlSelectVolumeByID, resourceID).Scan(row).Error; err != nil {
+	query := db
+	if unscoped {
+		query = db.Unscoped()
+	}
+	if err := query.Raw(sqlSelectVolumeByID, resourceID).Scan(row).Error; err != nil {
 		logger.Errorf("[%s] extractVolumeInfo: query failed id=%d err=%v elapsed=%s",
 			traceID, resourceID, err, time.Since(start))
 		return nil, err


### PR DESCRIPTION


{"time":"2026-06-02T07:05:24.423997888Z","level":"DEBUG","msg":"Kafka produce success: {01KT3JDG66JK7RBDE6S2JD8S6K instance_deleted Cloudland **Cloudland.instance_deleted.691c8ddb-7702-4621-82a4-621c82cece69.prestaging.67c8708d-b5c0-488e-93a3-a921270a3bef.deleted** 2026-06-02 07:05:24.422502879 +0000 UTC 691c8ddb-7702-4621-82a4-621c82cece69 prestaging  {instance 67c8708d-b5c0-488e-93a3-a921270a3bef  prestaging map[]} [] map[cpu:1 disk:20 hostname:dragon-test1-1780383881 hyper_id:0 memory:1024 status:deleted zone_id:1] map[]}","service":"push-ingest","module":"mercury/push-ingest"}
{"time":"2026-06-02T07:05:24.424474471Z","level":"INFO","msg":"Request Method: POST, Path: /mercury/ingestion/v1/events, Status: 200, Content-Length: 371, Content-Type: application/json, Duration: 1.27221ms, IP: 199.180.100.90, Origin: , User-Agent: CloudLand-Callback/1.0, Errors: , Body:\n{\"event_type\":\"instance_deleted\",\"source\":\"Cloudland\",\"occurred_at\":\"2026-06-02T07:05:24.422502879Z\",\"tenant_id\":\"691c8ddb-7702-4621-82a4-621c82cece69\",\"resource\":{\"type\":\"instance\",\"id\":\"67c8708d-b5c0-488e-93a3-a921270a3bef\",\"region\":\"prestaging\"},\"data\":{\"cpu\":1,\"disk\":20,\"hostname\":\"dragon-test1-1780383881\",\"hyper_id\":0,\"memory\":1024,\"status\":\"deleted\",\"zone_id\":1}}","service":"push-ingest","module":"api/middleware"}
