### PR TITLE
PET-1541 fixed the missing target_node issue

### DIFF
--- a/web/src/callback/metadata.go
+++ b/web/src/callback/metadata.go
@@ -305,7 +305,7 @@ func extractInstanceInfo(db *gorm.DB, resourceID int64, unscoped bool, args []st
 					}
 				}
 				// Fall back to the instance's current hyper — after migration this is the target.
-				if mr.TargetHyper < 0 {
+				if mr.TargetHyper <= 0 {
 					mr.TargetHyper = row.Hyper
 				}
 

--- a/web/src/callback/metadata.go
+++ b/web/src/callback/metadata.go
@@ -304,6 +304,10 @@ func extractInstanceInfo(db *gorm.DB, resourceID int64, unscoped bool, args []st
 						mr.TargetHyper = int32(fallbackHyperID)
 					}
 				}
+				// Fall back to the instance's current hyper — after migration this is the target.
+				if mr.TargetHyper < 0 {
+					mr.TargetHyper = row.Hyper
+				}
 
 				type hyperName struct {
 					Hostname string

--- a/web/src/callback/metadata.go
+++ b/web/src/callback/metadata.go
@@ -313,7 +313,7 @@ func extractInstanceInfo(db *gorm.DB, resourceID int64, unscoped bool, args []st
 					Hostname string
 				}
 				// source hyper hostname
-				if mr.SourceHyper > 0 {
+				if mr.SourceHyper >= 0 {
 					sn := &hyperName{}
 					if err := db.Raw(`SELECT hostname FROM hypers WHERE hostid = ? LIMIT 1`, mr.SourceHyper).Scan(sn).Error; err != nil {
 						logger.Warningf("[%s] extractInstanceInfo: source hyper query failed hostid=%d: %v", traceID, mr.SourceHyper, err)
@@ -322,7 +322,7 @@ func extractInstanceInfo(db *gorm.DB, resourceID int64, unscoped bool, args []st
 					}
 				}
 				// target hyper hostname
-				if mr.TargetHyper > 0 {
+				if mr.TargetHyper >= 0 {
 					tn := &hyperName{}
 					if err := db.Raw(`SELECT hostname FROM hypers WHERE hostid = ? LIMIT 1`, mr.TargetHyper).Scan(tn).Error; err != nil {
 						logger.Warningf("[%s] extractInstanceInfo: target hyper query failed hostid=%d: %v", traceID, mr.TargetHyper, err)


### PR DESCRIPTION
```plaintext
// 1. DB query target_hyper
qMig := `SELECT source_hyper, target_hyper FROM migrations WHERE id = ?`

// 2. target_hyper <= 0 → fallback to args[4]
if mr.TargetHyper <= 0 && len(args) > 4 { ... }

// 3. target_hyper <= 0 → fallback to row.Hyper
if mr.TargetHyper <= 0 { mr.TargetHyper = row.Hyper }
```
