### PR TITLE
PET-1541 fixed the missing target_node issue

### DIFF
--- a/web/src/callback/metadata.go
+++ b/web/src/callback/metadata.go
@@ -305,7 +305,7 @@ func extractInstanceInfo(db *gorm.DB, resourceID int64, unscoped bool, args []st
 					}
 				}
 				// Fall back to the instance's current hyper — after migration this is the target.
-				if mr.TargetHyper <= 0 {
+				if mr.TargetHyper < 0 {
 					mr.TargetHyper = row.Hyper
 				}
 


### PR DESCRIPTION
No callback needed for mr.TargetHyper if its value is zero.