### PR TITLE
PET-1758 add prometheus remote post speed

### DIFF
--- a/deploy/roles/metering_prometheus/tasks/main.yml
+++ b/deploy/roles/metering_prometheus/tasks/main.yml
@@ -17,9 +17,13 @@
           tls_config:
             insecure_skip_verify: true
           queue_config:
+            capacity: 10000
+            max_shards: 8
+            min_shards: 2
+            max_samples_per_send: 5000
             batch_send_deadline: 5m
-            max_samples_per_send: 50000
-            max_shards: 1
+            min_backoff: 30ms
+            max_backoff: 5s
           write_relabel_configs:
             - source_labels: [__name__]
               regex: 'libvirt_domain_info_vstate|domain_north_south_.*|libvirt_domain_info_virtual_cpus|libvirt_domain_info_maximum_memory_bytes|libvirt_domain_block_stats_capacity_bytes|vm_instance_map|cloud_snapshot_snap_size_bytes|cloud_snapshot_data_size_bytes'


### PR DESCRIPTION
PET-1758: tune Prometheus remote_write queue_config (multi-shard, larger buffer, softer backoff) to stop transient network blips from causing multi-hour metering data backlogs