### PR TITLE
PET-1860 change compute node filter on blocked IP page from a text input to a dropdown populated from Prometheus hostname label values

### DIFF
--- a/web/conf/locale/locale_en-US.ini
+++ b/web/conf/locale/locale_en-US.ini
@@ -532,6 +532,7 @@ InstanceUUID = Instance UUID
 Blocked_IP_Address = Blocked IP
 Owner_Instance = Owning instance
 Compute_Node = Compute node
+All_Compute_Nodes = All compute nodes
 Mapping_Gap = Mapping gap
 Query_Range = queried
 Window_Truncated = The requested range held more data than one query may carry, so only the most recent part is shown. Ownership and direction are resolved over that same narrowed range, so some rows may read NA or name the wrong side. Narrow the range or add a filter for a complete answer.

--- a/web/conf/locale/locale_zh-CN.ini
+++ b/web/conf/locale/locale_zh-CN.ini
@@ -534,6 +534,7 @@ InstanceUUID = 实例 UUID
 Blocked_IP_Address = 被封 IP
 Owner_Instance = 归属实例
 Compute_Node = 计算节点
+All_Compute_Nodes = 全部计算节点
 Mapping_Gap = 映射缺口
 Query_Range = 查询范围
 Window_Truncated = 请求的时间范围数据量超过单次查询上限，仅显示最近的一段。归属实例与方向也是在这段收窄后的范围内解析的，因此部分行可能显示 NA 或判错方向。缩小时间范围或增加筛选条件即可得到完整结果。

--- a/web/src/routes/blocked_ip.go
+++ b/web/src/routes/blocked_ip.go
@@ -227,6 +227,55 @@ func (a *BlockedIPAdmin) ListHistory(filter *BlockedIPFilter, start, end time.Ti
 	return a.resolve(episodes, start, end, window), window, nil
 }
 
+// ListHostnames names every compute node the blocking metric has carried a
+// label for, so the filter can be a dropdown instead of a field the operator has
+// to spell correctly -- the filter matches the label exactly, so a single typo
+// reads as "nothing is blocked" rather than as a mistake.
+//
+// The names come from the label index rather than from the hyper table because
+// only the index is guaranteed to match what the filter compares against:
+// export_blocked_ips.sh writes the label from `hostname -f` on the node itself,
+// which need not be the hostname the database holds, and an option that can
+// never match is worse than no option at all.
+//
+// The lookup spans the whole retention rather than the window on screen. It
+// reads no samples, so the span costs nothing, and a node whose blockings are
+// older than the current range is exactly the one an operator is about to widen
+// the range to find.
+func (a *BlockedIPAdmin) ListHostnames() (hostnames []string, err error) {
+	end := time.Now().UTC()
+	params := url.Values{}
+	params.Set("match[]", blockedIPMetric)
+	params.Set("start", strconv.FormatInt(end.Add(-blockedIPMaxWindow).Unix(), 10))
+	params.Set("end", strconv.FormatInt(end.Unix(), 10))
+	resp, err := blockedIPGet("label/hostname/values", params, blockedIPMetric)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	result := &blockedIPLabelValuesResponse{}
+	if err = json.NewDecoder(resp.Body).Decode(result); err != nil {
+		logger.Errorf("Failed to decode prometheus label values response, %v", err)
+		return nil, err
+	}
+	if result.Status == "error" {
+		err = fmt.Errorf("prometheus reported an error: %s: %s", result.ErrorType, result.Error)
+		logger.Errorf("Prometheus reported an error: %v, label: hostname", err)
+		return nil, err
+	}
+	return result.Data, nil
+}
+
+// blockedIPLabelValuesResponse is what /api/v1/label/<name>/values answers: the
+// distinct values a label takes, without the series carrying them, so its size
+// is set by the number of compute nodes and by nothing else.
+type blockedIPLabelValuesResponse struct {
+	Status    string   `json:"status"`
+	ErrorType string   `json:"errorType"`
+	Error     string   `json:"error"`
+	Data      []string `json:"data"`
+}
+
 // BlockedIPBudgetError says the range asked for holds more than one query may
 // move, and that narrowing it to what fits left nothing behind.
 //

--- a/web/src/routes/blocked_ip_view.go
+++ b/web/src/routes/blocked_ip_view.go
@@ -146,7 +146,17 @@ func (v *BlockedIPView) render(c *macaron.Context, tab string, blocked []*Blocke
 	c.Data["BlockedIPs"] = blocked[offset:last]
 	c.Data["Tab"] = tab
 	c.Data["IP"] = c.QueryTrim("ip")
-	c.Data["Hostname"] = c.QueryTrim("hostname")
+	hostname := c.QueryTrim("hostname")
+	c.Data["Hostname"] = hostname
+	// The compute node filter is a dropdown over what the metric actually
+	// carries, so a value picked from it always matches. Failing to reach
+	// Prometheus for the option list costs the filter and not the page --
+	// everything above it has already been resolved by the time we get here.
+	hostnames, err := blockedIPAdmin.ListHostnames()
+	if err != nil {
+		logger.Warningf("Failed to list blocked ip compute nodes: %v", err)
+	}
+	c.Data["Hostnames"] = blockedIPHostnameOptions(hostnames, hostname)
 	// datetime-local renders whatever it is handed, so the resolved window goes
 	// out as UTC and the browser turns it into local time -- the same handoff
 	// scheduled_tasks_patch.tmpl uses. Feeding back the resolved window rather
@@ -196,6 +206,23 @@ func (v *BlockedIPView) render(c *macaron.Context, tab string, blocked []*Blocke
 		`["Hostname", "IP", "Direction", "InstanceUUID", "BlockedAt", "ExpiresAt"]`,
 		[]string{"Hostname", "IP", "Direction", "InstanceUUID", "BlockedAt", "ExpiresAt"})
 	c.HTML(http.StatusOK, "blocked_ips")
+}
+
+// blockedIPHostnameOptions keeps the node being filtered on in the dropdown even
+// when the metric no longer carries it, so the control cannot disagree with the
+// filter actually applied: a node whose blockings have aged out of retention
+// would otherwise leave the select reading "all nodes" while the query behind it
+// still narrowed to that one.
+func blockedIPHostnameOptions(hostnames []string, selected string) []string {
+	if selected == "" {
+		return hostnames
+	}
+	for _, hostname := range hostnames {
+		if hostname == selected {
+			return hostnames
+		}
+	}
+	return append(hostnames, selected)
 }
 
 // blockedIPExtraQuery carries the filters through the pagination links, which

--- a/web/templates/blocked_ips.tmpl
+++ b/web/templates/blocked_ips.tmpl
@@ -38,7 +38,12 @@
                                 </div>
                                 <div class="field">
                                     <label for="hostname">{{.i18n.Tr "Compute_Node"}}</label>
-                                    <input id="hostname" name="hostname" value="{{ .Hostname }}">
+                                    <select id="hostname" name="hostname" class="ui selection dropdown">
+                                        <option value="">{{.i18n.Tr "All_Compute_Nodes"}}</option>
+                                        {{ range .Hostnames }}
+                                        <option value="{{ . }}" {{ if eq $.Hostname . }}selected{{ end }}>{{ . }}</option>
+                                        {{ end }}
+                                    </select>
                                 </div>
                                 {{ if eq .Tab "history" }}
                                 <div class="field">


### PR DESCRIPTION
PET-1860 change compute node filter on blocked IP page from a text input to a dropdown populated from Prometheus hostname label values