### PR TITLE
PET-1920: placement anti-fragmentation — tiered pack/spread + reserve…

### DIFF
--- a/web/conf/placement.toml
+++ b/web/conf/placement.toml
@@ -47,10 +47,13 @@ host_report_interval_sec = 60
 #   resource       检查 vCPU / 内存 / 磁盘是否充足
 #   cpu_load       检查 CPU 空闲率是否高于 idle_threshold_pct
 #   affinity       按 Owner 的亲和/反亲和策略过滤（需 VM 创建时传入 Policy）
+#   reserve        从已通过所有硬约束的候选节点中，排除空闲资源最多的 N 台（大订单缓冲节点）；
+#                  若排除后候选为空（本单只有大节点才能承载），则回退到全部候选正常调度。
+#                  ★ 必须放在所有硬约束过滤器之后，否则排除的节点未经资源校验。
 #
 # 注意：zone 过滤在 DB 查询层完成（WHERE zone_id=?），无需在此添加 "zone"。
 # 调整顺序会影响性能：将淘汰率高的过滤器放前面可减少后续计算量。
-filter_chain = ["compute_alive", "resource", "cpu_load", "affinity"]
+filter_chain = ["compute_alive", "resource", "cpu_load", "affinity", "reserve"]
 
 # weigher_chain —— 评分器链（软性排序，对候选节点综合评分）
 #
@@ -93,6 +96,29 @@ page_size_kb = 2048
 #   - 调低（如 5.0）： 接受更高负载的节点，可用节点更多，但 VM 性能可能受影响
 # 例：设为 15.0，则 CPU 使用率超过 85% 的节点不参与调度
 idle_threshold_pct = 15.0
+
+[placement.filters.reserve]
+# reserve 是否生效由 filter_chain 是否包含 reserve 决定。
+#
+# count —— 每个 zone 预留的"大订单缓冲节点"数量
+#
+# 背景：打散策略（默认）会把小订单均匀铺满所有节点，久而久之每台节点的剩余空间
+# 都磨成差不多大小的"碎渣"，再来大订单（如 32 核）时，总量够但每台都装不下。
+# 解法：始终保留 N 台空闲资源最多的节点不参与普通调度，专门留给大订单备用。
+#
+# 调度逻辑（在已通过所有硬约束过滤器的候选节点中执行）：
+#   1. 按 vCPU 剩余量降序，标记 top-N 为"预留节点"
+#   2. 从候选中排除预留节点，在剩余节点中调度
+#   3. 若排除后无候选（说明只有预留节点才能容纳本单），则允许使用预留节点
+#
+# 举例（count=2，zone 有 5 台节点）：
+#   小订单（4核）：5 台均通过 resource 过滤，排除最大两台 → 从剩余 3 台调度 ✓
+#   大订单（32核）：只有最大 2 台通过 resource 过滤 → 排除这 2 台后为空 → 回退使用这 2 台 ✓
+#
+# count = 0  禁用预留（等同于不加 reserve 过滤器）
+# count = 2  默认值，适合大多数生产 zone
+# count = 1  zone 节点数较少时可降为 1
+count = 2
 
 [placement.overcommit]
 
@@ -191,34 +217,41 @@ ram_multiplier = 1.0
 #   A 的贡献比 B 多 1.0 分（完全归一化时）
 cpu_load_multiplier = 1.0
 
-# spread_multiplier —— 打散 / 堆叠策略系数
+# spread_multiplier —— 打散/打包策略的权重系数
 #
-# SpreadWeigher 的 raw score = 节点当前已有 VM 数量（InstanceCount）。
-# VM 数越多，raw score 越高。
+# SpreadWeigher 的原始分 = 节点当前已有 VM 数量（InstanceCount），方向由
+# pack_vcpu_threshold 动态决定（见下方说明），系数符号不再决定方向，只控制权重大小。
+# 代码取绝对值使用，因此正负均可，效果等价。
 #
-# ★ 关键：通过系数符号控制策略方向：
+# 举例（设为 1.0，2 台候选节点 A=0 VM，B=10 VM）：
+#   打散模式（默认）：A 优先（VM少的节点得高分）
+#   打包模式（小订单）：B 优先（VM多的节点得高分）
 #
-#   负值（默认 -1.0）= 打散优先：
-#     VM 少的节点 raw score 低 → 归一化后反而获得更高的加权分
-#     效果：VM 均匀分散到各节点，避免单节点过载
-#     适用：独享型 zone、在线业务、希望资源隔离
+# 绝对值越大，该维度对最终选择影响越大，其他维度（ram / cpu_load）越难扳回。
+# 建议范围 1.0 ~ 3.0
+spread_multiplier = 1.0
+
+# pack_vcpu_threshold —— 打包策略的 vCPU 阈值（核数）
 #
-#   正值 = 堆叠优先：
-#     VM 多的节点 raw score 高 → 获得更高加权分
-#     效果：VM 尽量堆叠到少数节点，让更多节点保持空闲
-#     适用：共享型 zone、离线批处理、希望整节点空出以便维护
+# 背景：小订单持续以打散方式调度，会把每台节点剩余空间均匀磨成碎片，
+# 导致大订单（如 32 核）"总量够但每台都装不下"。
 #
-# 举例：
-#   spread_multiplier = -2.0（强力打散）
-#     节点 A 有 0 个 VM，节点 B 有 10 个 VM
-#     A raw=0, B raw=10；归一化后 A=1.0, B=0.0
-#     A 在此维度比 B 多 2.0 分 → 强烈倾向选 A
+# 解决思路：小订单改用"打包"策略，主动选已有更多 VM 的节点（让节点快速填满），
+# 把"干净"节点留给大订单，使节点自然分化为"填满的"和"大块空闲的"两类。
 #
-#   spread_multiplier = 2.0（堆叠优先）
-#     同样情形下 B 比 A 多 2.0 分 → 倾向选已有 VM 的节点 B
+# 逻辑：
+#   req.VCPUs ≤ pack_vcpu_threshold → 打包（选 VM 最多的节点，填满已有负载的节点）
+#   req.VCPUs > pack_vcpu_threshold → 打散（默认，选 VM 最少的节点）
 #
-# 绝对值越大，该策略越强势，其他维度难以扳回；建议范围 ±1.0 ~ ±3.0
-spread_multiplier = -1.0
+# 设为 0 禁用打包策略，所有订单统一使用打散（兼容旧行为）。
+# 建议值：等于当前在售规格中的小规格上限（如最大小规格为 8 核则设 8）。
+pack_vcpu_threshold = 8
+
+# spread_vcpu_threshold —— 大规格订单的 vCPU 参考阈值（核数，仅文档用途）
+#
+# 大订单（req.VCPUs ≥ 此值）使用打散策略；这是默认行为（pack 范围之外均打散），
+# 此参数不参与代码判断，仅作为运维参考，说明"多少核以上视为大订单"的界定。
+spread_vcpu_threshold = 16
 
 ##############################################################################
 # per-zone 覆盖配置
@@ -234,6 +267,7 @@ spread_multiplier = -1.0
 
 # zone ID=0 —— 共享型，资源超配，倾向堆叠以提高利用率
 [placement.zone.0]
+# 共享型无需预留大订单缓冲节点（资源超配、弹性大），去掉 reserve
 filter_chain = ["compute_alive", "resource", "cpu_load"]
 fallback_filter = "overcommit"
 
@@ -243,13 +277,18 @@ vcpu_delta_ratio_pct = 20.0
 cpu_idle_fallback_pct = 3.0
 
 [placement.zone.0.weighers]
-# 共享型倾向堆叠（提高节点利用率），超配惩罚较轻
-spread_multiplier            = 2.0
+# 共享型：所有订单均打包（节点利用率优先），禁用按规格分层
+spread_multiplier             = 1.0
 overcommit_penalty_multiplier = 1.0
+pack_vcpu_threshold           = 999  # 任何规格都走打包
+spread_vcpu_threshold         = 999  # 参考值，与 pack_vcpu_threshold 保持一致
 
-# zone ID=1 —— 独享型，资源独占，禁用超配，打散部署
+[placement.zone.0.filters.reserve]
+count = 0  # 共享型不预留
+
+# zone ID=1 —— 独享型，资源独占，禁用超配，分层打散/打包 + 大订单节点预留
 [placement.zone.1]
-filter_chain = ["compute_alive", "resource", "affinity"]
+filter_chain = ["compute_alive", "resource", "affinity", "reserve"]
 fallback_filter = "overcommit"
 
 [placement.zone.1.overcommit]
@@ -257,9 +296,14 @@ fallback_filter = "overcommit"
 enabled = false
 
 [placement.zone.1.weighers]
-# 独享型打散部署，超配惩罚权重保持高位
-spread_multiplier            = -2.0
+# 独享型：小订单（≤8核）打包，大订单（>8核）打散；权重加大以压倒其他维度
+spread_multiplier             = 2.0
 overcommit_penalty_multiplier = 3.0
+pack_vcpu_threshold           = 8
+spread_vcpu_threshold         = 16  # 参考值
+
+[placement.zone.1.filters.reserve]
+count = 2  # 始终保留 2 台空闲最多的节点给大订单备用
 
 # zone ID=2 —— prestaging zone1
 [placement.zone.2]

--- a/web/conf/placement.toml
+++ b/web/conf/placement.toml
@@ -47,8 +47,8 @@ host_report_interval_sec = 60
 #   resource       检查 vCPU / 内存 / 磁盘是否充足
 #   cpu_load       检查 CPU 空闲率是否高于 idle_threshold_pct
 #   affinity       按 Owner 的亲和/反亲和策略过滤（需 VM 创建时传入 Policy）
-#   reserve        从已通过所有硬约束的候选节点中，排除空闲资源最多的 N 台（大订单缓冲节点）；
-#                  若排除后候选为空（本单只有大节点才能承载），则回退到全部候选正常调度。
+#   reserve        从已通过所有硬约束的候选节点中，排除 vCPU 空闲最多的 top-N 台；
+#                  若排除后候选为空，则回退到全部候选（对所有规格统一生效）。
 #                  ★ 必须放在所有硬约束过滤器之后，否则排除的节点未经资源校验。
 #
 # 注意：zone 过滤在 DB 查询层完成（WHERE zone_id=?），无需在此添加 "zone"。
@@ -100,22 +100,21 @@ idle_threshold_pct = 15.0
 [placement.filters.reserve]
 # reserve 是否生效由 filter_chain 是否包含 reserve 决定。
 #
-# count —— 每个 zone 预留的"大订单缓冲节点"数量
+# count —— 每个 zone 从候选池中排除的 top-N 节点数（按 vCPU 剩余量降序）
 #
-# 背景：打散策略（默认）会把小订单均匀铺满所有节点，久而久之每台节点的剩余空间
-# 都磨成差不多大小的"碎渣"，再来大订单（如 32 核）时，总量够但每台都装不下。
-# 解法：始终保留 N 台空闲资源最多的节点不参与普通调度，专门留给大订单备用。
+# 调度逻辑（在已通过所有硬约束过滤器的候选节点中执行，对所有规格统一生效）：
+#   1. 按 vCPU 剩余量降序，标记 top-N 为"排除节点"
+#   2. 从候选中排除这 N 台，在剩余节点中调度
+#   3. 若排除后候选为空（说明只有这 N 台能容纳本单），则回退使用全部候选
 #
-# 调度逻辑（在已通过所有硬约束过滤器的候选节点中执行）：
-#   1. 按 vCPU 剩余量降序，标记 top-N 为"预留节点"
-#   2. 从候选中排除预留节点，在剩余节点中调度
-#   3. 若排除后无候选（说明只有预留节点才能容纳本单），则允许使用预留节点
+# 效果：vCPU 最空闲的节点只有在"没有别的节点装得下"时才会被使用，
+# 从而把最大空间留给对资源要求最高的请求。
 #
-# 举例（count=2，zone 有 5 台节点）：
-#   小订单（4核）：5 台均通过 resource 过滤，排除最大两台 → 从剩余 3 台调度 ✓
-#   大订单（32核）：只有最大 2 台通过 resource 过滤 → 排除这 2 台后为空 → 回退使用这 2 台 ✓
+# 举例（count=2，zone 有 5 台节点，vCPU 空闲 A=40、B=30、C=20、D=10、E=5）：
+#   4核请求 → 5 台均通过 resource → 排除 A、B → 从 C/D/E 中调度 ✓
+#   32核请求 → 只有 A、B 通过 resource → 排除后为空 → 回退使用 A/B ✓
 #
-# count = 0  禁用预留（等同于不加 reserve 过滤器）
+# count = 0  禁用（等同于不加 reserve 过滤器）
 # count = 2  默认值，适合大多数生产 zone
 # count = 1  zone 节点数较少时可降为 1
 count = 2
@@ -247,11 +246,6 @@ spread_multiplier = 1.0
 # 建议值：等于当前在售规格中的小规格上限（如最大小规格为 8 核则设 8）。
 pack_vcpu_threshold = 8
 
-# spread_vcpu_threshold —— 大规格订单的 vCPU 参考阈值（核数，仅文档用途）
-#
-# 大订单（req.VCPUs ≥ 此值）使用打散策略；这是默认行为（pack 范围之外均打散），
-# 此参数不参与代码判断，仅作为运维参考，说明"多少核以上视为大订单"的界定。
-spread_vcpu_threshold = 16
 
 ##############################################################################
 # per-zone 覆盖配置
@@ -281,7 +275,6 @@ cpu_idle_fallback_pct = 3.0
 spread_multiplier             = 1.0
 overcommit_penalty_multiplier = 1.0
 pack_vcpu_threshold           = 999  # 任何规格都走打包
-spread_vcpu_threshold         = 999  # 参考值，与 pack_vcpu_threshold 保持一致
 
 [placement.zone.0.filters.reserve]
 count = 0  # 共享型不预留
@@ -300,7 +293,6 @@ enabled = false
 spread_multiplier             = 2.0
 overcommit_penalty_multiplier = 3.0
 pack_vcpu_threshold           = 8
-spread_vcpu_threshold         = 16  # 参考值
 
 [placement.zone.1.filters.reserve]
 count = 2  # 始终保留 2 台空闲最多的节点给大订单备用

--- a/web/src/apis/placement.go
+++ b/web/src/apis/placement.go
@@ -107,6 +107,109 @@ func (v *PlacementAPI) Available(c *gin.Context) {
 	})
 }
 
+// GetConfig returns the current placement config as JSON.
+// Supports optional ?zone_id=<id> query parameter to get the effective merged
+// config for a specific zone (per-zone overrides merged onto global).
+// @Summary      Get placement configuration
+// @Description  Returns global config, or effective merged config for a specific zone
+// @Tags         Placement
+// @Produce      json
+// @Param        zone_id  query int false "Zone ID (0 or omit = global config)"
+// @Success      200 {object} map[string]interface{}
+// @Failure      403 {object} common.APIError
+// @Router       /placement/config [get]
+func (v *PlacementAPI) GetConfig(c *gin.Context) {
+	ctx := c.Request.Context()
+	memberShip := GetMemberShip(ctx)
+	if !memberShip.CheckPermission(model.Admin) {
+		ErrorResponse(c, http.StatusForbidden, "Not authorized for this operation", nil)
+		return
+	}
+
+	zoneID, _ := strconv.ParseInt(c.Query("zone_id"), 10, 64)
+
+	var cfg *scheduler.PlacementConfig
+	if zoneID > 0 {
+		cfg = scheduler.ResolveZoneConfig(zoneID)
+	} else {
+		cfg, _ = scheduler.GetCurrentConfig()
+	}
+
+	_, loadedAt := scheduler.GetCurrentConfig()
+	c.JSON(http.StatusOK, gin.H{
+		"zone_id":            zoneID,
+		"config":             cfg,
+		"loaded_at":          loadedAt,
+		"available_filters":  scheduler.GetRegisteredFilters(),
+		"available_weighers": scheduler.GetRegisteredWeighers(),
+	})
+}
+
+// GetDecisions returns recent placement decisions.
+// @Summary      Get recent placement decisions
+// @Description  Returns the most recent placement scheduling decisions (max 100)
+// @Tags         Placement
+// @Produce      json
+// @Param        limit  query int false "Number of decisions to return (default 20, max 100)"
+// @Success      200 {object} map[string]interface{}
+// @Failure      403 {object} common.APIError
+// @Router       /placement/decisions [get]
+func (v *PlacementAPI) GetDecisions(c *gin.Context) {
+	ctx := c.Request.Context()
+	memberShip := GetMemberShip(ctx)
+	if !memberShip.CheckPermission(model.Admin) {
+		ErrorResponse(c, http.StatusForbidden, "Not authorized for this operation", nil)
+		return
+	}
+	_ = ctx
+
+	n, _ := strconv.Atoi(c.Query("limit"))
+	if n <= 0 || n > 100 {
+		n = 20
+	}
+	decisions := scheduler.GetRecentDecisions(n)
+	c.JSON(http.StatusOK, gin.H{
+		"decisions": decisions,
+		"count":     len(decisions),
+	})
+}
+
+// Reload re-reads placement.toml and rebuilds the scheduler chains without restarting.
+// @Summary      Reload placement configuration
+// @Description  Hot-reloads placement.toml and invalidates the host state cache
+// @Tags         Placement
+// @Produce      json
+// @Success      200 {object} map[string]interface{}
+// @Failure      403 {object} common.APIError
+// @Failure      500 {object} common.APIError
+// @Router       /placement/reload [post]
+func (v *PlacementAPI) Reload(c *gin.Context) {
+	ctx := c.Request.Context()
+	memberShip := GetMemberShip(ctx)
+	if !memberShip.CheckPermission(model.Admin) {
+		ErrorResponse(c, http.StatusForbidden, "Not authorized for this operation", nil)
+		return
+	}
+	_ = ctx
+
+	result, err := scheduler.ReloadConfig()
+	if err != nil {
+		ErrorResponse(c, http.StatusInternalServerError, "Config reload failed", err)
+		return
+	}
+
+	scheduler.InvalidateHostStateCache()
+
+	logger.Infof("placement config reloaded via API by user %s, filters=%v, weighers=%v",
+		memberShip.UserName, result.FilterChain, result.WeigherChain)
+	c.JSON(http.StatusOK, gin.H{
+		"loaded_at":     result.LoadedAt,
+		"config_path":   result.ConfigPath,
+		"filter_chain":  result.FilterChain,
+		"weigher_chain": result.WeigherChain,
+	})
+}
+
 // Validate checks whether a specific hyper can host a VM with the given spec.
 // @Summary      Validate hyper resource availability
 // @Description  Checks if the specified hyper passes the filter chain for the given VM spec

--- a/web/src/apis/routes.go
+++ b/web/src/apis/routes.go
@@ -219,6 +219,9 @@ authGroup.GET("/api/v1/consistency_groups", consistencyGroupAPI.List)
 
 		authGroup.GET("/api/v1/placement/available", placementAPI.Available)
 		authGroup.POST("/api/v1/placement/validate", placementAPI.Validate)
+		authGroup.GET("/api/v1/placement/config", placementAPI.GetConfig)
+		authGroup.GET("/api/v1/placement/decisions", placementAPI.GetDecisions)
+		authGroup.POST("/api/v1/placement/reload", placementAPI.Reload)
 
 		authGroup.POST("/api/v1/instances/:id/set_user_password", instanceAPI.SetUserPassword)
 		authGroup.POST("/api/v1/instances/:id/console", consoleAPI.Create)

--- a/web/src/scheduler/config.go
+++ b/web/src/scheduler/config.go
@@ -52,9 +52,8 @@ type ZonePlacementConfig struct {
 		HugepageMultiplier          *float64 `mapstructure:"hugepage_multiplier"`
 		RAMMultiplier               *float64 `mapstructure:"ram_multiplier"`
 		CPULoadMultiplier           *float64 `mapstructure:"cpu_load_multiplier"`
-		SpreadMultiplier            *float64 `mapstructure:"spread_multiplier"`
-		PackVCPUThreshold           *int32   `mapstructure:"pack_vcpu_threshold"`
-		SpreadVCPUThreshold         *int32   `mapstructure:"spread_vcpu_threshold"`
+		SpreadMultiplier  *float64 `mapstructure:"spread_multiplier"`
+		PackVCPUThreshold *int32   `mapstructure:"pack_vcpu_threshold"`
 	} `mapstructure:"weighers"`
 }
 
@@ -92,8 +91,10 @@ type PlacementConfig struct {
 		} `mapstructure:"cpu_load"`
 
 		Reserve struct {
-			// Number of top-resource nodes to reserve per zone for large orders.
-			// 0 disables reservation. Default 2.
+			// Number of top-vCPU-free nodes to exclude from the candidate pool per zone.
+			// Applies to all request sizes uniformly: if non-reserved candidates can
+			// satisfy the request they are used; otherwise the reserved nodes are the
+			// fallback. 0 disables this behaviour. Default 2.
 			Count int `mapstructure:"count"`
 		} `mapstructure:"reserve"`
 	} `mapstructure:"filters"`
@@ -114,9 +115,8 @@ type PlacementConfig struct {
 		RAMMultiplier               float64 `mapstructure:"ram_multiplier"`
 		CPULoadMultiplier           float64 `mapstructure:"cpu_load_multiplier"`
 		SpreadMultiplier            float64 `mapstructure:"spread_multiplier"`
-		// Tiered pack/spread thresholds (VCPUs). 0 disables tiered logic.
-		PackVCPUThreshold   int32 `mapstructure:"pack_vcpu_threshold"`
-		SpreadVCPUThreshold int32 `mapstructure:"spread_vcpu_threshold"`
+		// PackVCPUThreshold: VCPUs <= this → pack strategy; 0 disables tiered logic.
+		PackVCPUThreshold int32 `mapstructure:"pack_vcpu_threshold"`
 	} `mapstructure:"weighers"`
 
 	// Per-zone override configs: key = zone ID string (e.g. "1").
@@ -162,7 +162,6 @@ func defaultConfig() *PlacementConfig {
 	cfg.Weighers.CPULoadMultiplier = 1.0
 	cfg.Weighers.SpreadMultiplier = -1.0
 	cfg.Weighers.PackVCPUThreshold = 8
-	cfg.Weighers.SpreadVCPUThreshold = 16
 	return cfg
 }
 

--- a/web/src/scheduler/config.go
+++ b/web/src/scheduler/config.go
@@ -32,6 +32,10 @@ type ZonePlacementConfig struct {
 		CPULoad *struct {
 			IdleThresholdPct *float64 `mapstructure:"idle_threshold_pct"`
 		} `mapstructure:"cpu_load"`
+
+		Reserve *struct {
+			Count *int `mapstructure:"count"`
+		} `mapstructure:"reserve"`
 	} `mapstructure:"filters"`
 
 	// Overrides global overcommit section (field-level merge)
@@ -49,6 +53,8 @@ type ZonePlacementConfig struct {
 		RAMMultiplier               *float64 `mapstructure:"ram_multiplier"`
 		CPULoadMultiplier           *float64 `mapstructure:"cpu_load_multiplier"`
 		SpreadMultiplier            *float64 `mapstructure:"spread_multiplier"`
+		PackVCPUThreshold           *int32   `mapstructure:"pack_vcpu_threshold"`
+		SpreadVCPUThreshold         *int32   `mapstructure:"spread_vcpu_threshold"`
 	} `mapstructure:"weighers"`
 }
 
@@ -84,6 +90,12 @@ type PlacementConfig struct {
 		CPULoad struct {
 			IdleThresholdPct float64 `mapstructure:"idle_threshold_pct"`
 		} `mapstructure:"cpu_load"`
+
+		Reserve struct {
+			// Number of top-resource nodes to reserve per zone for large orders.
+			// 0 disables reservation. Default 2.
+			Count int `mapstructure:"count"`
+		} `mapstructure:"reserve"`
 	} `mapstructure:"filters"`
 
 	// Overcommit fallback parameters.
@@ -102,6 +114,9 @@ type PlacementConfig struct {
 		RAMMultiplier               float64 `mapstructure:"ram_multiplier"`
 		CPULoadMultiplier           float64 `mapstructure:"cpu_load_multiplier"`
 		SpreadMultiplier            float64 `mapstructure:"spread_multiplier"`
+		// Tiered pack/spread thresholds (VCPUs). 0 disables tiered logic.
+		PackVCPUThreshold   int32 `mapstructure:"pack_vcpu_threshold"`
+		SpreadVCPUThreshold int32 `mapstructure:"spread_vcpu_threshold"`
 	} `mapstructure:"weighers"`
 
 	// Per-zone override configs: key = zone ID string (e.g. "1").
@@ -130,13 +145,14 @@ func defaultConfig() *PlacementConfig {
 		Enabled: false,
 		Log2DB:  true,
 		// "zone" filter removed: DB query already scopes hosts to the requested zone.
-		FilterChain:           []string{"compute_alive", "hugepage", "resource", "cpu_load", "affinity"},
+		FilterChain:           []string{"compute_alive", "hugepage", "resource", "cpu_load", "affinity", "reserve"},
 		WeigherChain:          []string{"overcommit_penalty", "hugepage", "ram", "cpu_load", "spread"},
 		FallbackFilter:        "overcommit",
 		HostReportIntervalSec: 60,
 	}
 	cfg.Filters.CPULoad.IdleThresholdPct = 15.0
 	cfg.Filters.Hugepage.PageSizeKB = 2048
+	cfg.Filters.Reserve.Count = 2
 	cfg.Overcommit.Enabled = true
 	cfg.Overcommit.VCPUDeltaRatioPct = 10.0
 	cfg.Overcommit.CPUIdleFallbackPct = 5.0
@@ -145,6 +161,8 @@ func defaultConfig() *PlacementConfig {
 	cfg.Weighers.RAMMultiplier = 1.0
 	cfg.Weighers.CPULoadMultiplier = 1.0
 	cfg.Weighers.SpreadMultiplier = -1.0
+	cfg.Weighers.PackVCPUThreshold = 8
+	cfg.Weighers.SpreadVCPUThreshold = 16
 	return cfg
 }
 

--- a/web/src/scheduler/config_loader.go
+++ b/web/src/scheduler/config_loader.go
@@ -346,9 +346,6 @@ func mergeZoneConfig(global *PlacementConfig, zone *ZonePlacementConfig) *Placem
 		if z.PackVCPUThreshold != nil {
 			merged.Weighers.PackVCPUThreshold = *z.PackVCPUThreshold
 		}
-		if z.SpreadVCPUThreshold != nil {
-			merged.Weighers.SpreadVCPUThreshold = *z.SpreadVCPUThreshold
-		}
 	}
 	return &merged
 }

--- a/web/src/scheduler/config_loader.go
+++ b/web/src/scheduler/config_loader.go
@@ -309,6 +309,10 @@ func mergeZoneConfig(global *PlacementConfig, zone *ZonePlacementConfig) *Placem
 				logger.Debugf("mergeZoneConfig: override cpu_load.idle_threshold_pct=%.1f", merged.Filters.CPULoad.IdleThresholdPct)
 			}
 		}
+		if z.Reserve != nil && z.Reserve.Count != nil {
+			merged.Filters.Reserve.Count = *z.Reserve.Count
+			logger.Debugf("mergeZoneConfig: override filters.reserve.count=%d", merged.Filters.Reserve.Count)
+		}
 	}
 	if zone.Overcommit != nil {
 		z := zone.Overcommit
@@ -338,6 +342,12 @@ func mergeZoneConfig(global *PlacementConfig, zone *ZonePlacementConfig) *Placem
 		}
 		if z.SpreadMultiplier != nil {
 			merged.Weighers.SpreadMultiplier = *z.SpreadMultiplier
+		}
+		if z.PackVCPUThreshold != nil {
+			merged.Weighers.PackVCPUThreshold = *z.PackVCPUThreshold
+		}
+		if z.SpreadVCPUThreshold != nil {
+			merged.Weighers.SpreadVCPUThreshold = *z.SpreadVCPUThreshold
 		}
 	}
 	return &merged

--- a/web/src/scheduler/filters/reserve.go
+++ b/web/src/scheduler/filters/reserve.go
@@ -1,0 +1,61 @@
+/*
+Copyright <holder> All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package filters
+
+import (
+	"context"
+	"sort"
+
+	"web/src/scheduler"
+)
+
+func init() {
+	scheduler.RegisterFilter("reserve", func(cfg *scheduler.PlacementConfig) scheduler.Filter {
+		return &ReserveFilter{count: cfg.Filters.Reserve.Count}
+	})
+}
+
+// ReserveFilter keeps the top-N nodes (by free vCPU) available for large orders.
+// It excludes those nodes from the candidate pool unless no other nodes pass.
+// This prevents small orders from consuming the nodes best suited for large orders.
+type ReserveFilter struct {
+	count int
+}
+
+func (f *ReserveFilter) Name() string { return "reserve" }
+
+func (f *ReserveFilter) Filter(_ context.Context, _ *scheduler.PlacementRequest, hosts []*scheduler.HostState) []*scheduler.HostState {
+	if f.count <= 0 || len(hosts) <= f.count {
+		return hosts
+	}
+
+	// Sort by VCPUFree descending to identify the top-N reserved nodes.
+	sorted := make([]*scheduler.HostState, len(hosts))
+	copy(sorted, hosts)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].VCPUFree > sorted[j].VCPUFree
+	})
+
+	reserved := make(map[int32]struct{}, f.count)
+	for i := 0; i < f.count; i++ {
+		reserved[sorted[i].HyperID] = struct{}{}
+	}
+
+	var nonReserved []*scheduler.HostState
+	for _, h := range hosts {
+		if _, ok := reserved[h.HyperID]; !ok {
+			nonReserved = append(nonReserved, h)
+		}
+	}
+	if len(nonReserved) == 0 {
+		// All candidates are reserved nodes — allow using them.
+		logger.Debugf("reserve: all %d candidates are reserved nodes, falling through", len(hosts))
+		return hosts
+	}
+	logger.Debugf("reserve: excluded %d reserved node(s), %d candidate(s) remain", f.count, len(nonReserved))
+	return nonReserved
+}

--- a/web/src/scheduler/filters/reserve.go
+++ b/web/src/scheduler/filters/reserve.go
@@ -19,9 +19,10 @@ func init() {
 	})
 }
 
-// ReserveFilter keeps the top-N nodes (by free vCPU) available for large orders.
-// It excludes those nodes from the candidate pool unless no other nodes pass.
-// This prevents small orders from consuming the nodes best suited for large orders.
+// ReserveFilter excludes the top-N nodes (by free vCPU) from the candidate pool,
+// regardless of request size. If excluding them leaves no candidates the filter
+// falls back to the full input set. This keeps the most-idle nodes available for
+// requests that only those nodes can satisfy.
 type ReserveFilter struct {
 	count int
 }

--- a/web/src/scheduler/weighers/spread.go
+++ b/web/src/scheduler/weighers/spread.go
@@ -15,9 +15,8 @@ import (
 func init() {
 	scheduler.RegisterWeigher("spread", func(cfg *scheduler.PlacementConfig) scheduler.Weigher {
 		return &SpreadWeigher{
-			multiplier:      cfg.Weighers.SpreadMultiplier,
-			packThreshold:   cfg.Weighers.PackVCPUThreshold,
-			spreadThreshold: cfg.Weighers.SpreadVCPUThreshold,
+			multiplier:    cfg.Weighers.SpreadMultiplier,
+			packThreshold: cfg.Weighers.PackVCPUThreshold,
 		}
 	})
 }
@@ -32,9 +31,8 @@ func init() {
 // Direction is encoded in Score (positive = pack, negative = spread) so that
 // Multiplier always returns a positive weight and the normalizer works uniformly.
 type SpreadWeigher struct {
-	multiplier      float64
-	packThreshold   int32 // VCPUs <= this → pack; 0 disables tiered logic
-	spreadThreshold int32 // VCPUs >= this → spread (informational, spread is the default)
+	multiplier    float64
+	packThreshold int32 // VCPUs <= this → pack; 0 disables tiered logic
 }
 
 func (w *SpreadWeigher) Name() string { return "spread" }

--- a/web/src/scheduler/weighers/spread.go
+++ b/web/src/scheduler/weighers/spread.go
@@ -6,24 +6,47 @@ SPDX-License-Identifier: Apache-2.0
 
 package weighers
 
-import "web/src/scheduler"
+import (
+	"math"
+
+	"web/src/scheduler"
+)
 
 func init() {
 	scheduler.RegisterWeigher("spread", func(cfg *scheduler.PlacementConfig) scheduler.Weigher {
-		return &SpreadWeigher{multiplier: cfg.Weighers.SpreadMultiplier}
+		return &SpreadWeigher{
+			multiplier:      cfg.Weighers.SpreadMultiplier,
+			packThreshold:   cfg.Weighers.PackVCPUThreshold,
+			spreadThreshold: cfg.Weighers.SpreadVCPUThreshold,
+		}
 	})
 }
 
-// SpreadWeigher scores hosts by their current instance count.
-// With negative multiplier (default -1.0): fewer VMs = higher final score (spread/打散).
-// With positive multiplier: more VMs = higher final score (pack/堆叠).
+// SpreadWeigher scores hosts by instance count with tiered pack/spread strategy.
+//
+// When req.VCPUs <= packThreshold (small orders): pack strategy — prefer nodes
+// already hosting more VMs, leaving low-utilization nodes free for large orders.
+//
+// Otherwise: spread strategy — prefer nodes with fewer VMs (current default).
+//
+// Direction is encoded in Score (positive = pack, negative = spread) so that
+// Multiplier always returns a positive weight and the normalizer works uniformly.
 type SpreadWeigher struct {
-	multiplier float64
+	multiplier      float64
+	packThreshold   int32 // VCPUs <= this → pack; 0 disables tiered logic
+	spreadThreshold int32 // VCPUs >= this → spread (informational, spread is the default)
 }
 
-func (w *SpreadWeigher) Name() string       { return "spread" }
-func (w *SpreadWeigher) Multiplier() float64 { return w.multiplier }
+func (w *SpreadWeigher) Name() string { return "spread" }
+
+// Multiplier returns the weight magnitude. Direction is in Score, so this is always positive.
+func (w *SpreadWeigher) Multiplier() float64 { return math.Abs(w.multiplier) }
 
 func (w *SpreadWeigher) Score(req *scheduler.PlacementRequest, h *scheduler.HostState) float64 {
-	return float64(h.InstanceCount)
+	if w.packThreshold > 0 && req.VCPUs <= w.packThreshold {
+		// pack: more VMs on this node = higher score = preferred
+		return float64(h.InstanceCount)
+	}
+	// spread: fewer VMs on this node = higher score = preferred (via negative raw)
+	return -float64(h.InstanceCount)
 }

--- a/web/src/scheduler/zone_config_test.go
+++ b/web/src/scheduler/zone_config_test.go
@@ -175,6 +175,8 @@ func TestMergeZoneConfig_WeigherMultiplierOverride(t *testing.T) {
 			RAMMultiplier               *float64 `mapstructure:"ram_multiplier"`
 			CPULoadMultiplier           *float64 `mapstructure:"cpu_load_multiplier"`
 			SpreadMultiplier            *float64 `mapstructure:"spread_multiplier"`
+			PackVCPUThreshold           *int32   `mapstructure:"pack_vcpu_threshold"`
+			SpreadVCPUThreshold         *int32   `mapstructure:"spread_vcpu_threshold"`
 		}{
 			SpreadMultiplier: ptrFloat(2.0), // positive = stack (edge zone)
 		},
@@ -200,6 +202,9 @@ func TestMergeZoneConfig_CPULoadThresholdOverride(t *testing.T) {
 			CPULoad *struct {
 				IdleThresholdPct *float64 `mapstructure:"idle_threshold_pct"`
 			} `mapstructure:"cpu_load"`
+			Reserve *struct {
+				Count *int `mapstructure:"count"`
+			} `mapstructure:"reserve"`
 		}{
 			CPULoad: &struct {
 				IdleThresholdPct *float64 `mapstructure:"idle_threshold_pct"`

--- a/web/src/scheduler/zone_config_test.go
+++ b/web/src/scheduler/zone_config_test.go
@@ -176,9 +176,8 @@ func TestMergeZoneConfig_WeigherMultiplierOverride(t *testing.T) {
 			CPULoadMultiplier           *float64 `mapstructure:"cpu_load_multiplier"`
 			SpreadMultiplier            *float64 `mapstructure:"spread_multiplier"`
 			PackVCPUThreshold           *int32   `mapstructure:"pack_vcpu_threshold"`
-			SpreadVCPUThreshold         *int32   `mapstructure:"spread_vcpu_threshold"`
 		}{
-			SpreadMultiplier: ptrFloat(2.0), // positive = stack (edge zone)
+			SpreadMultiplier: ptrFloat(2.0),
 		},
 	}
 	merged := mergeZoneConfig(global, zone)


### PR DESCRIPTION
… filter

SpreadWeigher: when req.VCPUs <= pack_vcpu_threshold (default 8), switch to pack strategy (prefer nodes with more VMs); otherwise keep default spread. Direction encoded in Score(), Multiplier() always returns abs value. pack_vcpu_threshold = 0 disables pack and restores original behavior.

ReserveFilter: new filter placed at end of filter_chain. Excludes the top-N nodes by VCPUFree (default N=2) from candidate pool so small orders don't consume the nodes best suited for large orders. Falls back to full candidate list when all passing nodes are reserved (large order path).

Config: add filters.reserve.count, weighers.pack_vcpu_threshold, weighers.spread_vcpu_threshold (informational). All fields support per-zone override. Update placement.toml with new sections and detailed comments.